### PR TITLE
Fix escaping of JSON payload.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
       <version>4.2.3</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+      <version>1.0.4</version>
+    </dependency>
   </dependencies>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->


### PR DESCRIPTION
Use javax.json to create a JSON payload that escapes the content
that is sent to Jira.  This fixes 400 Bad request responses from
Jira whenever the test failure message has a double quote.

This also reformats the data sent to Jira so that it's formatted a bit
more nicely.
