### PR TITLE
Mark the workspace field as transient.

### DIFF
--- a/src/main/java/JiraTestResultReporter/JiraReporter.java
+++ b/src/main/java/JiraTestResultReporter/JiraReporter.java
@@ -43,7 +43,7 @@ public class JiraReporter extends Notifier {
     public boolean verboseDebugFlag;
     public boolean createAllFlag;
 
-    private FilePath workspace;
+    private transient FilePath workspace;
 
     private static final int JIRA_SUCCESS_CODE = 201;
 


### PR DESCRIPTION
This fixes a crash when attempting to save a job that uses this plugin and
the job has been run on a slave: "Can't send a remote FilePath to a different
remote channel".
