### PR TITLE
Add a feature to set the Affects version on each new Jira ticket.

### DIFF
--- a/src/main/resources/JiraTestResultReporter/JiraReporter/help.html
+++ b/src/main/resources/JiraTestResultReporter/JiraReporter/help.html
@@ -1,3 +1,11 @@
 <div>
-Automatically create an issue in Jira for every failed unit test.
+<p>Automatically create an issue in Jira for every failed unit test.</p>
+
+<p>You may optionally set the Affects version on the Jira ticket by setting
+an environment variable called JiraTestResultReporter_affectsVersion equal
+to the name of the appropriate version in Jira.  To do that you could use
+<a href="https://wiki.jenkins-ci.org/display/JENKINS/Environment+Script+Plugin">
+the Environment Script Plugin</a> or
+<a href="https://wiki.jenkins-ci.org/display/JENKINS/EnvInject+Plugin">
+the EnvInject Plugin</a>.</p>
 </div>


### PR DESCRIPTION
This uses an environment variable called JiraTestResultReporter_affectsVersion.
If that is set, the version is looked up on Jira, and the appropriate
Affects version is set when the ticket is created.

This is entirely optional.
