### PR TITLE
JENKINS-52338 - added a missing data publisher for AutoUnlink checkbox

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -94,6 +94,10 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         return JobConfigMapping.getInstance().getAutoResolveIssue(getJobName());
     }
 
+    public boolean getAutoUnlinkIssue() {
+        return JobConfigMapping.getInstance().getAutoUnlinkIssue(getJobName());
+    }
+
     /**
      * Getter for the project associated with this publisher
      * @return


### PR DESCRIPTION
This is a fix for defect: https://issues.jenkins-ci.org/browse/JENKINS-52338

Due to this issue, the saved value of "AutoUnlink issue" checkbox was not loading while editing a Jenkins job.

Verified by building plugin locally and using local Jenkins.