### PR TITLE
JENKINS-52341 - added logic to handle project residing under sub-folder

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/api/TestToIssueMappingApi.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/api/TestToIssueMappingApi.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonElement;
 import hudson.matrix.MatrixProject;
 import hudson.model.Api;
 import hudson.model.Job;
+import hudson.model.Item;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.JiraTestResultReporter.TestToIssueMapping;
 import org.kohsuke.stapler.StaplerRequest;
@@ -42,16 +43,30 @@ public class TestToIssueMappingApi extends Api {
             return;
         }
 
-        //sub job of a matrix project
+        // sub job of a matrix project or a folder
         if(jobName.contains("/")) {
             String matrixJobName = jobName.split("/")[0];
             String matrixSubJobName = jobName.split("/")[1];
-            MatrixProject matrixProject = (MatrixProject) Jenkins.getActiveInstance().getItem(matrixJobName);
-            if(matrixProject == null) {
-                rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
-                return;
+            Item item = Jenkins.getActiveInstance().getItem(matrixJobName);
+
+            // check if it is matrix project
+            if(item.getClass().equals(MatrixProject.class)) {
+                MatrixProject matrixProject = (MatrixProject) item;
+                if(matrixProject == null) {
+                    rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                    return;
+                }
+                result = TestToIssueMapping.getInstance().getMap(matrixProject, matrixSubJobName);
             }
-            result = TestToIssueMapping.getInstance().getMap(matrixProject, matrixSubJobName);
+            // else consider job resides in a sub-folder
+            else {
+                Job job = (Job) Jenkins.getActiveInstance().getItemByFullName(jobName);
+                if (job == null) {
+                    rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                    return;
+                }
+                result = TestToIssueMapping.getInstance().getMap(job);
+            }
         // top level job (either matrix, freestyle or maven
         } else {
             Job job = (Job) Jenkins.getActiveInstance().getItem(jobName);


### PR DESCRIPTION
This is a fix for defect: https://issues.jenkins-ci.org/browse/JENKINS-52341

Older logic was assuming that if argument job contains character "/" then it is a matrix project. But this was causing conflict when a normal Jenkins job exists under some sub-folder. This fix will check if the parent item to the job is Matrix project then will be processed accordingly. If it is not Matrix project then it will simply get item by full name (to resolve the full Jenkins job path).

Verified by building the plugin locally and on local Jenkins.