### PR TITLE
Added jenkins identifier for UserFields

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/UserFields.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/UserFields.java
@@ -12,6 +12,7 @@ import hudson.model.Descriptor;
 import hudson.tasks.test.TestResult;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.JiraTestResultReporter.JiraTestDataPublisher;
 import org.jenkinsci.plugins.JiraTestResultReporter.JiraUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -68,6 +69,7 @@ public class UserFields extends AbstractFields {
      */
     public String getValue() { return value; }
 
+    @Symbol("jiraUserField")
     @Extension
     public static class UserFieldsDescriptor extends Descriptor<AbstractFields> {
         @Override


### PR DESCRIPTION
I was not able via the jenkins pipeline to add the assignee. This as
the UserField option was not marked identifiable. This commit adds
the pertinent annotation to fix that.