### PR TITLE
JENKINS-61171: Bump dependency to jira-rest-java-client-core:5.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,21 +6,21 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
-    <version>2.37</version>
+    <version>3.50</version>
     <relativePath />
   </parent>
 
   <properties>
-    <jenkins.version>2.27</jenkins.version>
-    <jira-rest-client.version>4.0.0</jira-rest-client.version>
-    <fugue.version>2.6.1</fugue.version>
+    <jenkins.version>2.138.4</jenkins.version>
+    <jira-rest-client.version>5.2.1</jira-rest-client.version>
+    <fugue.version>3.0.0</fugue.version>
     <findbugs.failOnError>false</findbugs.failOnError>
     <java.level>8</java.level>
   </properties>
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>JiraTestResultReporter</artifactId>
-  <version>2.0.7-SNAPSHOT</version>
+  <version>2.0.8-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Jenkins JiraTestResultReporter plugin</name>
   <description>Creates issues in Jira for failed tests and/or link them directly in Jenkins.</description>
@@ -116,14 +116,14 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
-      <version>1.21</version>
+      <version>1.28</version>
       <scope>compile</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.6</version>
+      <version>1.14</version>
     </dependency>
 
     <dependency>
@@ -157,7 +157,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.atlassian.fugue</groupId>
+      <groupId>io.atlassian.fugue</groupId>
       <artifactId>fugue</artifactId>
       <version>${fugue.version}</version>
       <scope>runtime</scope>
@@ -165,12 +165,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
-      <version>4.5.3</version>
+      <version>4.5.10</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.3</version>
+      <version>4.5.10</version>
       <exclusions>
         <exclusion>
           <groupId>commons-codec</groupId>
@@ -180,18 +180,28 @@
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-cache</artifactId>
+      <version>4.5.10</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
       <artifactId>fluent-hc</artifactId>
-      <version>4.5.3</version>
+      <version>4.5.10</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>3.5.0</version>
+      <version>3.6.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.8.1</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -21,7 +21,7 @@ import com.atlassian.jira.rest.client.api.domain.BasicIssue;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
-import com.atlassian.util.concurrent.Promise;
+import io.atlassian.util.concurrent.Promise;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.ExtensionPoint;

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -24,7 +24,7 @@ import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
 import com.atlassian.jira.rest.client.auth.BasicHttpAuthenticationHandler;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousHttpClientFactory;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
-import com.atlassian.util.concurrent.Promise;
+import io.atlassian.util.concurrent.Promise;
 import hudson.*;
 import hudson.matrix.MatrixConfiguration;
 import hudson.model.*;

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -21,7 +21,7 @@ import com.atlassian.jira.rest.client.api.domain.BasicIssue;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
 import com.atlassian.jira.rest.client.api.domain.util.ErrorCollection;
-import com.atlassian.util.concurrent.Promise;
+import io.atlassian.util.concurrent.Promise;
 import hudson.EnvVars;
 import hudson.model.Job;
 import hudson.tasks.test.TestResult;

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/FullStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/FullStatus.java
@@ -31,7 +31,7 @@ public class FullStatus extends Status {
      * @param statusCategory
      */
     public FullStatus(Status status, StatusCategory statusCategory) {
-        super(status.getSelf(), status.getId(), status.getName(), status.getDescription(), status.getIconUrl());
+        super(status.getSelf(), status.getId(), status.getName(), status.getDescription(), status.getIconUrl(), status.getStatusCategory());
         this.statusCategory = statusCategory;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/JiraRestClientExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/JiraRestClientExtension.java
@@ -18,7 +18,7 @@ package org.jenkinsci.plugins.JiraTestResultReporter.restclientextensions;
 import com.atlassian.httpclient.api.HttpClient;
 import com.atlassian.jira.rest.client.internal.async.AbstractAsynchronousRestClient;
 import com.atlassian.jira.rest.client.internal.json.GenericJsonArrayParser;
-import com.atlassian.util.concurrent.Promise;
+import io.atlassian.util.concurrent.Promise;
 
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;


### PR DESCRIPTION
 *  Promise has moved to new namespace: io.atlassian.util.concurrent.Promise
 *  Bump dependecies for Jenkins and jenkins-ci to run tests