### PR TITLE
[JENKINS-56371] Fix on multiple junit publishers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -17,12 +17,7 @@ package org.jenkinsci.plugins.JiraTestResultReporter;
 
 import com.atlassian.jira.rest.client.api.IssueRestClient;
 import com.atlassian.jira.rest.client.api.RestClientException;
-import com.atlassian.jira.rest.client.api.domain.BasicIssue;
 import com.atlassian.jira.rest.client.api.domain.Issue;
-import com.atlassian.jira.rest.client.api.domain.SearchResult;
-import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
-import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
-import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
 import io.atlassian.util.concurrent.Promise;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -31,13 +26,10 @@ import hudson.matrix.MatrixProject;
 import hudson.model.*;
 import hudson.tasks.junit.CaseResult;
 import hudson.tasks.junit.TestAction;
-import hudson.tasks.test.TestResult;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.tools.ant.taskdefs.condition.And;
-import org.jenkinsci.plugins.JiraTestResultReporter.config.AbstractFields;
 import org.jenkinsci.plugins.JiraTestResultReporter.restclientextensions.FullStatus;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
@@ -273,7 +265,7 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
         IssueRestClient restClient = JiraUtils.getJiraDescriptor().getRestClient().getIssueClient();
         try {
             Promise<Issue> issuePromise = restClient.getIssue(issueKey);
-            Issue issue = issuePromise.claim();
+            issuePromise.claim();
         }catch (RestClientException e) {
             JiraUtils.logError("Error when validating issue", e);
             return false;


### PR DESCRIPTION
### Highlights

- Fixes [JENKINS-56371](https://issues.jenkins.io/browse/JENKINS-56371)
- Also fixes on attach ticket to test result on duplicated entries that are case results
- Before this PR
![Captura de pantalla de 2021-11-26 12-46-03](https://user-images.githubusercontent.com/595347/143576257-f217c37f-3914-4db2-aee3-34fed635c80f.png)
- After this PR
![Captura de pantalla de 2021-11-26 12-46-19](https://user-images.githubusercontent.com/595347/143576282-00e93c0a-0b57-489e-81b6-dad2ccc6c633.png)
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
