### PR TITLE
[JENKINS-56371] Fix on multiple junit publishers (2nd round)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -266,9 +266,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         for(CaseResult test : testCaseResults) {
             if(test.isFailed()) {
                 try {
-                    if (TestToIssueMapping.getInstance().getTestIssueKey(job, test.getId()) == null || test.isFailed()) {
-                        JiraUtils.createIssue(job, project, envVars, test);
-                    }
+                    JiraUtils.createIssue(job, project, envVars, test);
                     raised = true;
                 } catch (RestClientException e) {
                     listener.error("Could not create issue for test " + test.getFullDisplayName() + "\n");


### PR DESCRIPTION
See [JENKINS-56371](https://issues.jenkins.io/browse/JENKINS-56371)

### Highlights
- Previous PR (https://github.com/jenkinsci/JiraTestResultReporter-plugin/pull/23) was not properly working at all. 
- Previous PR was only fixing one corner case, now `TestData` is provided in a proper way
- Tested locally:
![Captura de pantalla de 2021-11-29 16-55-24](https://user-images.githubusercontent.com/595347/143900269-2076a079-6845-4c95-996d-1ab455b64f3f.png)

### Checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
