### PR TITLE
Bugfix autoresolve test reference on different stage name

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -100,7 +100,7 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
 
         this.testData = testData;
         this.test = test;
-        issueKey = TestToIssueMapping.getInstance().getTestIssueKey(job, test.getId());
+        issueKey = TestToIssueMapping.getInstance().getTestIssueKey(job, test.getTransformedFullDisplayName());
         if (issueKey != null) {
             IssueRestClient issueRestClient = JiraUtils.getJiraDescriptor().getRestClient().getIssueClient();
             try {
@@ -172,13 +172,13 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
      */
     @JavaScriptMethod
     public FormValidation setIssueKey(String issueKey) {
-        synchronized (test.getId()) {
-            if(TestToIssueMapping.getInstance().getTestIssueKey(job, test.getId()) != null) {
+        synchronized (test.getTransformedFullDisplayName()) {
+            if(TestToIssueMapping.getInstance().getTestIssueKey(job, test.getTransformedFullDisplayName()) != null) {
                 return null;
             }
             if (isValidIssueKey(issueKey)) {
                 this.issueKey = issueKey;
-                TestToIssueMapping.getInstance().addTestToIssueMapping(job, test.getId(), issueKey);
+                TestToIssueMapping.getInstance().addTestToIssueMapping(job, test.getTransformedFullDisplayName(), issueKey);
                 return null;
             }
             return FormValidation.error("Not a valid issue key");
@@ -190,7 +190,7 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
      */
     @JavaScriptMethod
     public void clearIssueKey() {
-        TestToIssueMapping.getInstance().removeTestToIssueMapping(job, test.getId(), issueKey);
+        TestToIssueMapping.getInstance().removeTestToIssueMapping(job, test.getTransformedFullDisplayName(), issueKey);
         issueKey = null;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -100,11 +100,11 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
 
         this.testData = testData;
         this.test = test;
-        issueKey = TestToIssueMapping.getInstance().getTestIssueKey(job, test.getTransformedFullDisplayName());
-        if (issueKey != null) {
+        for (String key: JiraUtils.searchIssueKeys(job, testData.getEnvVars(), test)) {
+            issueKey = key;
             IssueRestClient issueRestClient = JiraUtils.getJiraDescriptor().getRestClient().getIssueClient();
             try {
-                Issue issue = issueRestClient.getIssue(issueKey).claim();
+                Issue issue = issueRestClient.getIssue(key).claim();
                 issueStatus = issue.getStatus().getName();
                 issueSummary = issue.getSummary();
                 JiraTestDataPublisher.JiraTestDataPublisherDescriptor jiraDescriptor = JiraUtils.getJiraDescriptor();
@@ -172,13 +172,13 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
      */
     @JavaScriptMethod
     public FormValidation setIssueKey(String issueKey) {
-        synchronized (test.getTransformedFullDisplayName()) {
-            if(TestToIssueMapping.getInstance().getTestIssueKey(job, test.getTransformedFullDisplayName()) != null) {
+        synchronized (test.getId()) {
+            if(TestToIssueMapping.getInstance().getTestIssueKey(job, test.getId()) != null) {
                 return null;
             }
             if (isValidIssueKey(issueKey)) {
                 this.issueKey = issueKey;
-                TestToIssueMapping.getInstance().addTestToIssueMapping(job, test.getTransformedFullDisplayName(), issueKey);
+                TestToIssueMapping.getInstance().addTestToIssueMapping(job, test.getId(), issueKey);
                 return null;
             }
             return FormValidation.error("Not a valid issue key");
@@ -190,7 +190,7 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
      */
     @JavaScriptMethod
     public void clearIssueKey() {
-        TestToIssueMapping.getInstance().removeTestToIssueMapping(job, test.getTransformedFullDisplayName(), issueKey);
+        TestToIssueMapping.getInstance().removeTestToIssueMapping(job, test.getId(), issueKey);
         issueKey = null;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -220,10 +220,10 @@ public class JiraTestDataPublisher extends TestDataPublisher {
     private boolean unlinkIssuesForPassedTests(TaskListener listener, Job project, Job job, EnvVars envVars, List<CaseResult> testCaseResults) {
         boolean unlinked = false;
         for(CaseResult test : testCaseResults) {
-            if(test.isPassed() &&  TestToIssueMapping.getInstance().getTestIssueKey(job, test.getId()) != null) {
-                synchronized (test.getId()) {
-                    String issueKey = TestToIssueMapping.getInstance().getTestIssueKey(job, test.getId());
-                    TestToIssueMapping.getInstance().removeTestToIssueMapping(job, test.getId(), issueKey);
+            if(test.isPassed() &&  TestToIssueMapping.getInstance().getTestIssueKey(job, test.getTransformedFullDisplayName()) != null) {
+                synchronized (test.getTransformedFullDisplayName()) {
+                    String issueKey = TestToIssueMapping.getInstance().getTestIssueKey(job, test.getTransformedFullDisplayName());
+                    TestToIssueMapping.getInstance().removeTestToIssueMapping(job, test.getTransformedFullDisplayName(), issueKey);
                     unlinked = true;
                 }
             }
@@ -238,9 +238,9 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         try {
             for(CaseResult test : testCaseResults) {
                 if(test.isPassed() && test.getPreviousResult() != null && test.getPreviousResult().isFailed()
-                        && TestToIssueMapping.getInstance().getTestIssueKey(job, test.getId()) != null) {
-                    synchronized (test.getId()) {
-                        String issueKey = TestToIssueMapping.getInstance().getTestIssueKey(job, test.getId());
+                        && TestToIssueMapping.getInstance().getTestIssueKey(job, test.getTransformedFullDisplayName()) != null) {
+                    synchronized (test.getTransformedFullDisplayName()) {
+                        String issueKey = TestToIssueMapping.getInstance().getTestIssueKey(job, test.getTransformedFullDisplayName());
                         IssueRestClient issueRestClient = getDescriptor().getRestClient().getIssueClient();
                         Issue issue = issueRestClient.getIssue(issueKey).claim();
                         boolean transitionExecuted = false;

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -113,8 +113,8 @@ public class JiraUtils {
     }
     
     public static String createIssue(Job job, Job project, EnvVars envVars, CaseResult test) throws RestClientException {
-        synchronized (test.getId()) { //avoid creating duplicated issues
-            if(TestToIssueMapping.getInstance().getTestIssueKey(job, test.getId()) != null) {
+        synchronized (test.getTransformedFullDisplayName()) { //avoid creating duplicated issues
+            if(TestToIssueMapping.getInstance().getTestIssueKey(job, test.getTransformedFullDisplayName()) != null) {
                 return null;
             }
 
@@ -125,12 +125,12 @@ public class JiraUtils {
                 String id = issueInput.getField(fi.getId()).getValue().toString();
                 JiraUtils.log(String.format("Ignoring creating issue '%s' as it would be a duplicate. (from Jira server)", id));
                 for (Issue issue: searchResult.getIssues()) {
-                    TestToIssueMapping.getInstance().addTestToIssueMapping(job, test.getId(), issue.getKey());
+                    TestToIssueMapping.getInstance().addTestToIssueMapping(job, test.getTransformedFullDisplayName(), issue.getKey());
                 }
                 return null;
             }
             String issueKey = JiraUtils.createIssueInput(issueInput, test);
-            TestToIssueMapping.getInstance().addTestToIssueMapping(job, test.getId(), issueKey);
+            TestToIssueMapping.getInstance().addTestToIssueMapping(job, test.getTransformedFullDisplayName(), issueKey);
             return issueKey;
         }
     }


### PR DESCRIPTION
### Highlights
- Current code of the plugin relies on `TestObject.getId()` method to setup the mapping between Jira tickets and failed tests
- Main issue here is that when we use this plugin on a multibranch pipeline with some dynamic branching names on its stages then, `autoresolve` capabilities will not work as expected due to some fixed tests could not be resolved, apparently because the fixed tests were executed on a different branch than the original test failure
- Root cause is because the `getId` method setups the branch name as part of the test reference, and this is stored in the `JiraIssueKeyToTestMap.json` file
- Example: 
```
{
  "junit/plugins/LdapPluginTest/ATH___ATH_5___login_no_such_user": "JIRA-12456",
  "junit/core/PluginManagerTest/ATH___ATH_0___reproduce": "JIRA-12345",
[...]
}
```
- So, if `LdapPluginTest#login_no_such_user` is fixed on next execution, BUT it is executed in a different branch, then it will not be marked as resolved
- Proposed fix is to search the issue key related to the test in the Jira server if it does not mach with the one from the local map.

### Testing performed
- Created a single pipeline that will run the same test (`test6o`) to fail in different stages (`ONE`, `TWO` and `THREE`). It will generate something like:
```
{
  "junit/test/SomeTest/test6o": "JIRA-66",
  "junit/test/SomeTest/TWO___test6o": "JIRA-66",
  "junit/test/SomeTest/THREE___test6o": "JIRA-66",
[...]
}
```
- Update the pipeline to make all to work and only execute it in the first stage `ONE`. Also update manually the map to just have the following entry:
```
{
  "junit/test/SomeTest/THREE___test6o": "JIRA-66",
}
```
- Once executed again, it will not be able to locate the JIRA ticket to resolve due to `TestObject.getId()` will not match. Thus, it will search for the key based on test in the Jira server and will transition it as expected
![Captura de pantalla de 2022-02-16 12-55-54](https://user-images.githubusercontent.com/595347/154259810-e7c99e7b-5782-42d8-a1a3-86b68fa4b8fa.png)

### Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
