### PR TITLE
Manual creation of Jira issues should use global config only

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraIssueTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraIssueTrigger.java
@@ -1,0 +1,9 @@
+package org.jenkinsci.plugins.JiraTestResultReporter;
+
+/**
+ * Represents which trigger will request for a Jira issue creation
+ * @author imontero
+ */
+public enum JiraIssueTrigger {
+    JOB, UI
+}

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraIssueTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraIssueTrigger.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.JiraTestResultReporter;
 
 /**
- * Represents which trigger will request for a Jira issue creation
+ * Represents what triggered the request for a Jira issue creation
  * @author imontero
  */
 public enum JiraIssueTrigger {

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -247,7 +247,7 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
     @JavaScriptMethod
     public FormValidation createIssue() {
         try {
-            String id = JiraUtils.createIssue(job, project, testData.getEnvVars(), test, false);
+            String id = JiraUtils.createIssue(job, project, testData.getEnvVars(), test, JiraIssueTrigger.UI);
             return StringUtils.isBlank(id) ? FormValidation.error("Duplicate already exists") : setIssueKey(id);  
         } catch (RestClientException e) {
             JiraUtils.logError("Error when creating issue", e);

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -247,7 +247,7 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
     @JavaScriptMethod
     public FormValidation createIssue() {
         try {
-            String id = JiraUtils.createIssue(job, project, testData.getEnvVars(), test);
+            String id = JiraUtils.createIssue(job, project, testData.getEnvVars(), test, false);
             return StringUtils.isBlank(id) ? FormValidation.error("Duplicate already exists") : setIssueKey(id);  
         } catch (RestClientException e) {
             JiraUtils.logError("Error when creating issue", e);

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -275,7 +275,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             for(CaseResult test : testCaseResults) {
                 if(test.isFailed()) {
                     try {
-                        JiraUtils.createIssue(job, project, envVars, test, true);
+                        JiraUtils.createIssue(job, project, envVars, test, JiraIssueTrigger.JOB);
                         raised = true;
                     } catch (RestClientException e) {
                         listener.error("Could not create issue for test " + test.getFullDisplayName() + "\n");

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -275,7 +275,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             for(CaseResult test : testCaseResults) {
                 if(test.isFailed()) {
                     try {
-                        JiraUtils.createIssue(job, project, envVars, test);
+                        JiraUtils.createIssue(job, project, envVars, test, true);
                         raised = true;
                     } catch (RestClientException e) {
                         listener.error("Could not create issue for test " + test.getFullDisplayName() + "\n");

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -109,16 +109,16 @@ public class JiraUtils {
     }
     
     public static String createIssue(Job job, EnvVars envVars, CaseResult test) throws RestClientException {
-        return createIssue(job, job, envVars, test, true);
+        return createIssue(job, job, envVars, test, JiraIssueTrigger.JOB);
     }
     
-    public static String createIssue(Job job, Job project, EnvVars envVars, CaseResult test, boolean fromJob) throws RestClientException {
+    public static String createIssue(Job job, Job project, EnvVars envVars, CaseResult test, JiraIssueTrigger trigger) throws RestClientException {
         synchronized (test.getId()) { //avoid creating duplicated issues
             if(TestToIssueMapping.getInstance().getTestIssueKey(job, test.getId()) != null) {
                 return null;
             }
 
-            IssueInput issueInput = JiraUtils.createIssueInput(project, test, envVars, fromJob);
+            IssueInput issueInput = JiraUtils.createIssueInput(project, test, envVars, trigger);
             SearchResult searchResult = JiraUtils.findIssues(project, test, envVars, issueInput);
             if (searchResult != null && searchResult.getTotal() > 0) {
                 boolean duplicate = false;
@@ -159,7 +159,7 @@ public class JiraUtils {
                 return issueKeys;
             }
             
-            IssueInput issueInput = JiraUtils.createIssueInput(job, test, envVars, true);
+            IssueInput issueInput = JiraUtils.createIssueInput(job, test, envVars, JiraIssueTrigger.JOB);
             SearchResult searchResult = JiraUtils.findIssues(job, test, envVars, issueInput);
             if (searchResult != null && searchResult.getTotal() > 0) {
                 for (Issue issue: searchResult.getIssues()) {
@@ -170,7 +170,7 @@ public class JiraUtils {
         }
     }
     
-    private static IssueInput createIssueInput(Job project, TestResult test, EnvVars envVars, boolean fromJob) {
+    private static IssueInput createIssueInput(Job project, TestResult test, EnvVars envVars, JiraIssueTrigger trigger) {
         final IssueInputBuilder newIssueBuilder = new IssueInputBuilder(
                 JobConfigMapping.getInstance().getProjectKey(project),
                 JobConfigMapping.getInstance().getIssueType(project));
@@ -179,7 +179,7 @@ public class JiraUtils {
             newIssueBuilder.setFieldInput(f.getFieldInput(test, envVars));
         }
         
-        if (fromJob) {
+        if (trigger.equals(JiraIssueTrigger.JOB)) {
             for (AbstractFields f : JobConfigMapping.getInstance().getConfig(project)) {
                 newIssueBuilder.setFieldInput(f.getFieldInput(test, envVars));
             }

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/TestToIssueMapping.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/TestToIssueMapping.java
@@ -204,7 +204,7 @@ public class TestToIssueMapping {
         }
 
         synchronized (jobMap) {
-            if(jobMap.get(testId).equals(issueKey)) {
+            if(jobMap.get(testId) != null && jobMap.get(testId).equals(issueKey)) {
                 jobMap.remove(testId);
                 saveMap(job, jobMap);
             }


### PR DESCRIPTION
### Highlights
- JiraTestResultReporter plugin relies on `JiraIssueJobConfigs.json` file to retrieve all the configuration fields to be used in generating Jira tickets on test failures
- If users setup in their Jenkinsfile something like:
```
[...]
def jiraFields = [jiraStringField(fieldKey: 'summary', value: jiraSummaryPrefix + '${TEST_PACKAGE_CLASS_METHOD_NAME}')]

jiraTestResultReporter(configs: jiraFields,
        projectKey: jiraProject,
        issueType: '3', 
        autoRaiseIssue: true,
        autoResolveIssue: false,
        autoUnlinkIssue: false
    )
```
- Where `jiraSummaryPrefix` is something calculated during the execution of the Jenkinsfile, then this value is being overridden every time in the JSON file mentioned above.
- In addition, if the user request to perform a Jira ticket creation through UI (badge) then the global configuration for summary and description is overridden by the one provided by the job execution (from the JSON file) which is wrong
- This PR tries to fix this issue by enforcing to use of the global configuration from UI generation (badge)

### Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
