### PR TITLE
Include overrideResolvedIssues parameter to create new tickets if test failure are linked to already resolved ones

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -24,24 +24,20 @@ import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
 import com.atlassian.jira.rest.client.api.domain.util.ErrorCollection;
-import io.atlassian.util.concurrent.Promise;
 import hudson.EnvVars;
 import hudson.model.Job;
 import hudson.tasks.junit.CaseResult;
 import hudson.tasks.test.TestResult;
+import io.atlassian.util.concurrent.Promise;
 import jenkins.model.Jenkins;
-
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.JiraTestResultReporter.config.AbstractFields;
 
-import java.io.ByteArrayInputStream;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * Created by tuicu.
@@ -107,17 +103,44 @@ public class JiraUtils {
         }
         return errorMessages.toString();
     }
-    
+
     public static String createIssue(Job job, EnvVars envVars, CaseResult test) throws RestClientException {
         return createIssue(job, job, envVars, test, JiraIssueTrigger.JOB);
     }
-    
+
+    public static boolean cleanJobCacheFile(List<CaseResult> testCaseResults, Job testJob){
+        List<String> testNames = testCaseResults.stream().filter(CaseResult::isFailed).map( CaseResult::getId ).collect( Collectors.toList());
+        HashMap<String, String> keysToCheck = new HashMap<>();
+        List<String> jiraIds = new ArrayList<>();
+        for (String test : testNames){
+            if(TestToIssueMapping.getInstance().getTestIssueKey(testJob, test) != null) {
+                String jiraId = TestToIssueMapping.getInstance().getTestIssueKey(testJob, test);
+                jiraIds.add(jiraId);
+                keysToCheck.put(jiraId, test);
+            }
+        }
+        if(keysToCheck.isEmpty()) {
+            return false;
+        }
+
+        SearchResult searchResult = JiraUtils.findUnresolvedJiraIssues(String.join(",", jiraIds));
+        if (searchResult != null && searchResult.getTotal() > 0) {
+            for (Issue issue: searchResult.getIssues()) {
+                String testKey = issue.getKey();
+                String testId = keysToCheck.get(testKey);
+                synchronized (testId) {
+                    TestToIssueMapping.getInstance().removeTestToIssueMapping(testJob, testId, testKey);
+                }
+            }
+        }
+        return true;
+    }
+
     public static String createIssue(Job job, Job project, EnvVars envVars, CaseResult test, JiraIssueTrigger trigger) throws RestClientException {
         synchronized (test.getId()) { //avoid creating duplicated issues
             if(TestToIssueMapping.getInstance().getTestIssueKey(job, test.getId()) != null) {
                 return null;
             }
-
             IssueInput issueInput = JiraUtils.createIssueInput(project, test, envVars, trigger);
             SearchResult searchResult = JiraUtils.findIssues(project, test, envVars, issueInput);
             if (searchResult != null && searchResult.getTotal() > 0) {
@@ -221,6 +244,14 @@ public class JiraUtils {
         FieldInput fi = JiraTestDataPublisher.JiraTestDataPublisherDescriptor.templates.get(0).getFieldInput(test, envVars);
         String jql = String.format("resolution = \"unresolved\" and project = \"%s\" and text ~ \"%s\"", projectKey, escapeJQL(issueInput.getField(fi.getId()).getValue().toString()));
 
+        return getSearchResult(jql);
+    }
+    private static SearchResult findUnresolvedJiraIssues(String keys) throws RestClientException {
+        String jql = String.format("key in (%s) and resolution != \"unresolved\" ", keys);
+        return getSearchResult(jql);
+    }
+
+    private static SearchResult getSearchResult(String jql) {
         final Set<String > fields = new HashSet<>();
         fields.add("issueKey");
         fields.add("summary");
@@ -229,8 +260,7 @@ public class JiraUtils {
         fields.add("updated");
         fields.add("project");
         fields.add("status");
-
-        log(jql);
+        JiraUtils.log(jql);
 
         Promise<SearchResult> searchJqlPromise = JiraUtils.getJiraDescriptor().getRestClient().getSearchClient().searchJql(jql, 50, 0, fields);
         return searchJqlPromise.claim();

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JobConfigMapping.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JobConfigMapping.java
@@ -47,6 +47,7 @@ public class JobConfigMapping {
         protected Long issueType;
         protected List<AbstractFields> configs;
         protected boolean autoRaiseIssue;
+        protected boolean overrideResolvedIssues;
         protected boolean autoResolveIssue;
         protected boolean autoUnlinkIssue;
         protected transient Pattern issueKeyPattern;
@@ -58,13 +59,15 @@ public class JobConfigMapping {
          * @param configs list with the configured fields
          */
         public JobConfigEntry(String projectKey, Long issueType, List<AbstractFields> configs,
-                              boolean autoRaiseIssue, boolean autoResolveIssue, boolean autoUnlinkIssue) {
+                              boolean autoRaiseIssue, boolean autoResolveIssue, boolean autoUnlinkIssue,
+                              boolean overrideResolvedIssues) {
             this.projectKey = projectKey;
             this.issueType = issueType;
             this.configs = configs;
             this.autoRaiseIssue = autoRaiseIssue;
             this.autoResolveIssue = autoResolveIssue;
             this.autoUnlinkIssue = autoUnlinkIssue;
+            this.overrideResolvedIssues = overrideResolvedIssues;
             compileIssueKeyPattern();
         }
 
@@ -93,6 +96,8 @@ public class JobConfigMapping {
         }
 
         public boolean getAutoRaiseIssue() { return autoRaiseIssue; }
+
+        public boolean getOverrideResolvedIssues() { return overrideResolvedIssues; }
 
         public boolean getAutoResolveIssue() { return  autoResolveIssue; }
 
@@ -127,7 +132,7 @@ public class JobConfigMapping {
          * Constructor
          */
         public JobConfigEntryBuilder() {
-            super(null, null, new ArrayList<>(), false, false, false);
+            super(null, null, new ArrayList<>(), false, false, false, false);
         }
 
         public JobConfigEntryBuilder withProjectKey(String projectKey) {
@@ -148,6 +153,11 @@ public class JobConfigMapping {
 
         public JobConfigEntryBuilder withAutoRaiseIssues(boolean autoRaiseIssues) {
             this.autoRaiseIssue = autoRaiseIssues;
+            return this;
+        }
+
+        public JobConfigEntryBuilder withOverrideResolvedIssues(boolean overrideResolvedIssues) {
+            this.overrideResolvedIssues = overrideResolvedIssues;
             return this;
         }
 
@@ -320,8 +330,9 @@ public class JobConfigMapping {
                                         List<AbstractFields> configs,
                                         boolean autoRaiseIssue,
                                         boolean autoResolveIssue,
-                                        boolean autoUnlinkIssue) {
-        JobConfigEntry entry = new JobConfigEntry(projectKey, issueType, configs, autoRaiseIssue, autoResolveIssue, autoUnlinkIssue);
+                                        boolean autoUnlinkIssue,
+                                        boolean overrideResolvedIssues) {
+        JobConfigEntry entry = new JobConfigEntry(projectKey, issueType, configs, autoRaiseIssue, autoResolveIssue, autoUnlinkIssue, overrideResolvedIssues);
         saveConfig(project, entry);
     }
 
@@ -379,6 +390,11 @@ public class JobConfigMapping {
     public boolean getAutoRaiseIssue(Job project) {
         JobConfigEntry entry = getJobConfigEntry(project);
         return entry != null ? entry.getAutoRaiseIssue() : false;
+    }
+
+    public boolean getOverrideResolvedIssues(Job project) {
+        JobConfigEntry entry = getJobConfigEntry(project);
+        return entry != null ? entry.getOverrideResolvedIssues() : false;
     }
 
     public boolean getAutoResolveIssue(Job project) {

--- a/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/help-overrideResolvedIssues.html
+++ b/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/help-overrideResolvedIssues.html
@@ -1,0 +1,3 @@
+<div>
+    Create issues automatically for failing tests that are linked to resolved issues in JiraIssueKeyToTestMap.json.
+</div>


### PR DESCRIPTION
Include a parameter that allows not link test failures to resolved issues. This change will clean up the `JiraIssueKeyToTestMap.json` entry (to a specific job) when a test failure is linked to a resolved ticket. 

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
