### PR TITLE
Add test class for JiraTestData.java (2 tests)

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataTest.java
+++ b/src/test/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataTest.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.JiraTestResultReporter;
+
+import hudson.EnvVars;
+import hudson.tasks.junit.CaseResult;
+import hudson.tasks.junit.SuiteResult;
+import hudson.tasks.junit.TestResult;
+import hudson.tasks.test.PipelineTestDetails;
+import hudson.tasks.test.TestObject;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class JiraTestDataTest {
+
+    private SuiteResult suiteResult;
+
+    private JiraTestData target;
+
+    @Before
+    public void setup() {
+        EnvVars envVars = new EnvVars();
+        PipelineTestDetails pipelineTestDetails = new PipelineTestDetails();
+        suiteResult = new SuiteResult("SuiteResult", StringUtils.EMPTY, StringUtils.EMPTY, pipelineTestDetails);
+        this.target = new JiraTestData(envVars);
+    }
+
+    @Test
+    public void getTestAction_canParseToCaseResult_shouldReturnListOfActions() {
+        CaseResult testObject = new CaseResult(suiteResult, StringUtils.EMPTY, StringUtils.EMPTY);
+        List<?> actionList = target.getTestAction(testObject);
+        Assert.assertEquals(1, actionList.size());
+        Assert.assertEquals(JiraTestAction.class, actionList.get(0).getClass());
+    }
+
+    @Test
+    public void getTestAction_failToParseToCaseResult_shouldReturnEmptyList() {
+        TestObject testObject = new TestResult();
+        List<?> actionList = target.getTestAction(testObject);
+        Assert.assertTrue(actionList.isEmpty());
+    }
+}


### PR DESCRIPTION
Addition of a simple test class for JiraTestData.java.
The project did not have any units from src/test/java so I have decided to get that ball rolling here.
issue: https://github.com/jenkinsci/JiraTestResultReporter-plugin/issues/101

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
