### PR TITLE
Add ? as supported char for queries against JIRA

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -274,8 +274,10 @@ public class JiraUtils {
      * Based on https://jira.atlassian.com/browse/JRASERVER-25092, currently supported:
      *  + - & | ~ *
      *  
+     * Also supported ? although JRSERVER-25092 defines the opposite
+     *  
      * Unsupported:
-     *  ! ( ) { } ^ ? \ /
+     *  ! ( ) { } ^ \ /
      *
      * Provides special support for parameterized tests by ignoring the parameter in [ ] 
      * 
@@ -290,7 +292,8 @@ public class JiraUtils {
                 .replace("&", "\\\\&")
                 .replace("\\|", "\\\\|")
                 .replace("~", "\\\\~")
-                .replace("\\*", "\\\\*");
+                .replace("\\*", "\\\\*")
+                .replace("?", "\\\\?");  // Although ? char is still not supported based on JRASERVER-25092
         
         if (result.contains("[")) {
             result = result.substring(0, result.lastIndexOf("[")); // let's remove the parameter part


### PR DESCRIPTION
### Highlights
- Provides support for using `?` char on queries against JIRA to search for duplicates
- Tested with `com.cloudbees.casc.e2e.BundleE2ETest.(?)` provides a valid escaped `com.cloudbees.casc.e2e.BundleE2ETest.(\\?)` which works perfectly fine with JIRA to query 

### Actions
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
