### PR TITLE
Fix race condition on using multiple publishers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -212,9 +212,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             JiraTestData data = new JiraTestData(envVars);
             TestResultAction action = run.getAction(TestResultAction.class);
             if (action != null) {
-                List<TestResultAction.Data> dataList = new LinkedList<>();
-                dataList.add(data);
-                action.setData(dataList);
+                action.addData(data);
                 return null;
             }
             return data;


### PR DESCRIPTION
### Highlights
- If we use multiple publishers in the `testDataPublisher` sometimes we hit a race condition where the rest of the data provided by other publishers goes away.
- The main reason is that the JiraTestDataPublisher was setting the data instead of adding new data


```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
