### PR TITLE
Test data should be added by the JUnitResultArchiver

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -176,7 +176,8 @@ public class JiraTestDataPublisher extends TestDataPublisher {
 	public TestResultAction.Data contributeTestData(Run<?, ?> run, @Nonnull FilePath workspace, Launcher launcher,
                                                     TaskListener listener, TestResult testResult)
                                                     throws IOException, InterruptedException {
-        EnvVars envVars = run.getEnvironment(listener);
+        
+	EnvVars envVars = run.getEnvironment(listener);
 
         Job job = run.getParent();
         Job project;
@@ -208,17 +209,8 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         if(JobConfigMapping.getInstance().getAutoUnlinkIssue(project)) {
             hasTestData |= unlinkIssuesForPassedTests(listener, project, job, envVars, getTestCaseResults(testResult));
         }
-        if (hasTestData) {
-            JiraTestData data = new JiraTestData(envVars);
-            TestResultAction action = run.getAction(TestResultAction.class);
-            if (action != null) {
-                action.addData(data);
-                return null;
-            }
-            return data;
-        } else {
-            return null;
-        }
+        
+        return hasTestData? new JiraTestData(envVars) : null;
 	}
 
     private boolean unlinkIssuesForPassedTests(TaskListener listener, Job project, Job job, EnvVars envVars, List<CaseResult> testCaseResults) {


### PR DESCRIPTION
- Method `contributeTestData` just should only to provide the test data to be included in the test result
- This method was wrongly adding that data here instead of deferring that to the `junit-plugin`. See https://github.com/jenkinsci/junit-plugin/blob/master/src/main/java/hudson/tasks/junit/JUnitResultArchiver.java#L294

### Testing done
- Tested locally and working as expected
![Captura de pantalla de 2024-01-08 16-39-15](https://github.com/jenkinsci/JiraTestResultReporter-plugin/assets/595347/f293cbf5-0946-4f5d-9f45-c0f7ef05c659)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
