### PR TITLE
Fix on parallel branches bug

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestData.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestData.java
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * Created by tuicu.
  */
-public class JiraTestData extends TestResultAction.Data {    
+public class JiraTestData extends TestResultAction.Data {
     private EnvVars envVars;
 
     /**
@@ -45,8 +45,8 @@ public class JiraTestData extends TestResultAction.Data {
     public EnvVars getEnvVars() {
         return envVars;
     }
-    
-    
+
+
     /**
      * Method for creating test actions associated with tests
      * @param testObject

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestData.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestData.java
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * Created by tuicu.
  */
-public class JiraTestData extends TestResultAction.Data {
+public class JiraTestData extends TestResultAction.Data {    
     private EnvVars envVars;
 
     /**
@@ -45,8 +45,8 @@ public class JiraTestData extends TestResultAction.Data {
     public EnvVars getEnvVars() {
         return envVars;
     }
-
-
+    
+    
     /**
      * Method for creating test actions associated with tests
      * @param testObject

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -210,8 +210,22 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             hasTestData |= unlinkIssuesForPassedTests(listener, project, job, envVars, getTestCaseResults(testResult));
         }
         
-        return hasTestData? new JiraTestData(envVars) : null;
+        if (hasTestData) {
+            // Workaround to make feasible to use the publisher in parallel executions
+            if (notReportedTestDataBefore(envVars)) {
+                JiraTestDataRegistry.getInstance().put(envVars);
+                return JiraTestDataRegistry.getInstance().get(envVars);
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
 	}
+
+    private boolean notReportedTestDataBefore(EnvVars envVars) {
+        return JiraTestDataRegistry.getInstance().get(envVars) == null;
+    }
 
     private boolean unlinkIssuesForPassedTests(TaskListener listener, Job project, Job job, EnvVars envVars, List<CaseResult> testCaseResults) {
         boolean unlinked = false;

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -212,9 +212,9 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         
         if (hasTestData) {
             // Workaround to make feasible to use the publisher in parallel executions
-            if (notReportedTestDataBefore(envVars)) {
-                JiraTestDataRegistry.getInstance().put(envVars);
-                return JiraTestDataRegistry.getInstance().get(envVars);
+            if (!reportedTestDataBefore(envVars)) {
+                JiraTestDataRegistry.getInstance().putJiraTestData(envVars);
+                return JiraTestDataRegistry.getInstance().getJiraTestData(envVars);
             } else {
                 return null;
             }
@@ -223,8 +223,8 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         }
 	}
 
-    private boolean notReportedTestDataBefore(EnvVars envVars) {
-        return JiraTestDataRegistry.getInstance().get(envVars) == null;
+    private boolean reportedTestDataBefore(EnvVars envVars) {
+        return JiraTestDataRegistry.getInstance().getJiraTestData(envVars) != null;
     }
 
     private boolean unlinkIssuesForPassedTests(TaskListener listener, Job project, Job job, EnvVars envVars, List<CaseResult> testCaseResults) {

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataRegistry.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataRegistry.java
@@ -21,14 +21,14 @@ public class JiraTestDataRegistry {
         return instance;
     }
 
-    public JiraTestData get(EnvVars envVars) {
+    public JiraTestData getJiraTestData(EnvVars envVars) {
         String key = envVars.get(BUILD_URL);
         synchronized (key) {
             return jiraTestDataByUrl.get(key);
         }
     }
 
-    public void put(EnvVars envVars) {
+    public void putJiraTestData(EnvVars envVars) {
         String key = envVars.get(BUILD_URL);
         synchronized (key) {
             jiraTestDataByUrl.put(key, new JiraTestData(envVars));

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataRegistry.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataRegistry.java
@@ -1,0 +1,37 @@
+package org.jenkinsci.plugins.JiraTestResultReporter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import hudson.EnvVars;
+
+public class JiraTestDataRegistry {
+    
+    private static final String BUILD_URL = "BUILD_URL";
+
+    private static JiraTestDataRegistry instance = new JiraTestDataRegistry();
+    
+    private Map<String, JiraTestData> jiraTestDataByUrl;
+    
+    private JiraTestDataRegistry() {
+        jiraTestDataByUrl = new HashMap<String, JiraTestData>(); 
+    }
+    
+    public static JiraTestDataRegistry getInstance() {
+        return instance;
+    }
+
+    public JiraTestData get(EnvVars envVars) {
+        String key = envVars.get(BUILD_URL);
+        synchronized (key) {
+            return jiraTestDataByUrl.get(key);
+        }
+    }
+
+    public void put(EnvVars envVars) {
+        String key = envVars.get(BUILD_URL);
+        synchronized (key) {
+            jiraTestDataByUrl.put(key, new JiraTestData(envVars));
+        }
+    }
+}


### PR DESCRIPTION
### Highlights
- Use of `parallel` in pipelines with the JiraTestDataResultReporter publisher makes this to provide repeated results on the /testReport due to multiple generations of duplicated JiraTestAction entities
- Then badge.jelly renders all of them for all the parallel branches
- Main reason is the generation of a JiraTestData for each branch execution. Each build should have only one JiraTestData to provide.
- This PR fixes this issue by maintaining in a in-memory registry all the mappings between JiraTestData and build URLs.
- Tested locally
- Before the PR
![Captura de pantalla de 2024-01-16 15-28-22](https://github.com/jenkinsci/JiraTestResultReporter-plugin/assets/595347/e5356a21-b0aa-4879-8720-3c875d1d6c9e)
- After the PR
![Captura de pantalla de 2024-01-18 12-27-15](https://github.com/jenkinsci/JiraTestResultReporter-plugin/assets/595347/95aec17d-843b-4981-a080-6462c76d1c2c)

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
