### PR TITLE
Added bearer token support

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/BearerAuthenticationHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/BearerAuthenticationHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Atlassian
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jenkinsci.plugins.JiraTestResultReporter;
+
+import com.atlassian.httpclient.api.Request;
+import com.atlassian.jira.rest.client.api.AuthenticationHandler;
+
+/**
+ * Handler for Bearer (Token) authentication
+ */
+public class BearerAuthenticationHandler implements AuthenticationHandler {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private final String token;
+
+    public BearerAuthenticationHandler(String token) {
+        this.token = token;
+    }
+
+    @Override
+    public void configure(Request.Builder builder) {
+        builder.setHeader(AUTHORIZATION_HEADER, "Bearer " + token);
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/global.jelly
@@ -15,8 +15,13 @@
         <f:entry title="Password">
             <f:password field="password"/>
         </f:entry>
+
+        <f:entry title="Use Bearer authentication instead of Basic authentication" field="useBearerAuth" >
+            <f:checkbox/>
+        </f:entry>
+
         <f:validateButton title="Validate settings"
-                          method="validateGlobal" with="jiraUrl,username,password" />
+                          method="validateGlobal" with="jiraUrl,username,password,useBearerAuth" />
         <f:advanced>
             <f:entry title="Default Summary" field="summary">
                 <f:textbox field="summary" default="${descriptor.defaultSummary}"/>

--- a/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/help-useBearerAuth.html
+++ b/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/help-useBearerAuth.html
@@ -1,0 +1,4 @@
+<div>
+    Uses password data as input for Bearer token, PAT(personal access token) access to enterprise jira (https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html).
+    Bearer authentication is only supported in Jira Server, for Jira Cloud leave this unchecked
+</div>


### PR DESCRIPTION
Fixes #140

- added global option for usage of password field for Bearer Token as described in #140, similar to jira plugin
- harmonized whitespace usage within the file and changes tabs to spaces.

<!-- Please describe your pull request here. -->

### Testing done

Tested with Jenkins https://www.jenkins.io/changelog-stable/#v2.462.2 and none cloud aka enterprise Jira. Change should be backwards compatible and the default behaviour is not to use the bearer token but basic auth as before.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
