### PR TITLE
replace deprecated getInstance and getActiveInstance calls 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -93,8 +93,7 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
     public JiraTestAction(JiraTestData testData, CaseResult test) {
         project = initProject();
         if (project instanceof MatrixProject) {
-            job = (Job) Jenkins.get()
-                    .getItemByFullName(testData.getEnvVars().get("JOB_NAME"));
+            job = (Job) Jenkins.get().getItemByFullName(testData.getEnvVars().get("JOB_NAME"));
         } else {
             job = project;
         }

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -93,7 +93,7 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
     public JiraTestAction(JiraTestData testData, CaseResult test) {
         project = initProject();
         if (project instanceof MatrixProject) {
-            job = (Job) Jenkins.getInstance()
+            job = (Job) Jenkins.get()
                     .getItemByFullName(testData.getEnvVars().get("JOB_NAME"));
         } else {
             job = project;
@@ -239,7 +239,7 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
      */
     @Override
     public Descriptor<JiraTestAction> getDescriptor() {
-        return (JiraTestActionDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (JiraTestActionDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -424,7 +424,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
      */
     @Override
     public JiraTestDataPublisherDescriptor getDescriptor() {
-        return (JiraTestDataPublisherDescriptor) Jenkins.getInstance().getDescriptorOrDie(getClass());
+        return (JiraTestDataPublisherDescriptor) Jenkins.get().getDescriptorOrDie(getClass());
     }
 
     /**
@@ -840,7 +840,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
          * @return
          */
         public List getListDescriptors() {
-            return Jenkins.getInstance().getDescriptorList(AbstractFields.class);
+            return Jenkins.get().getDescriptorList(AbstractFields.class);
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -90,7 +90,7 @@ public class JiraUtils {
      */
     public static JiraTestDataPublisher.JiraTestDataPublisherDescriptor getJiraDescriptor() {
         return (JiraTestDataPublisher.JiraTestDataPublisherDescriptor)
-                Jenkins.getInstance().getDescriptor(JiraTestDataPublisher.class);
+                Jenkins.get().getDescriptor(JiraTestDataPublisher.class);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JobConfigMapping.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JobConfigMapping.java
@@ -262,7 +262,7 @@ public class JobConfigMapping {
     private JobConfigMapping() {
         configMap = new HashMap<String, JobConfigEntry>();
 
-        for (Job project : Jenkins.getInstance().getItems(Job.class)) {
+        for (Job project : Jenkins.get().getItems(Job.class)) {
             JobConfigEntry entry = load(project);
             if (entry != null) {
                 configMap.put(project.getFullName(), entry);

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/TestToIssueMapping.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/TestToIssueMapping.java
@@ -57,7 +57,7 @@ public class TestToIssueMapping {
      */
     private TestToIssueMapping() {
         jobsMap = new HashMap<String, HashMap<String, String>>();
-        for (Job job : Jenkins.getInstance().getItems(Job.class)) {
+        for (Job job : Jenkins.get().getItems(Job.class)) {
             register(job);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/api/TestToIssueMappingApi.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/api/TestToIssueMappingApi.java
@@ -44,7 +44,7 @@ public class TestToIssueMappingApi extends Api {
         if (jobName.contains("/")) {
             String matrixJobName = jobName.split("/")[0];
             String matrixSubJobName = jobName.split("/")[1];
-            Item item = Jenkins.getActiveInstance().getItem(matrixJobName);
+            Item item = Jenkins.get().getItem(matrixJobName);
 
             // check if it is matrix project
             if (item instanceof MatrixProject) {
@@ -53,7 +53,7 @@ public class TestToIssueMappingApi extends Api {
             }
             // else consider job resides in a sub-folder
             else {
-                Job job = (Job) Jenkins.getActiveInstance().getItemByFullName(jobName);
+                Job job = (Job) Jenkins.get().getItemByFullName(jobName);
                 if (job == null) {
                     rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
                     return;
@@ -62,7 +62,7 @@ public class TestToIssueMappingApi extends Api {
             }
             // top level job (either matrix, freestyle or maven
         } else {
-            Job job = (Job) Jenkins.getActiveInstance().getItem(jobName);
+            Job job = (Job) Jenkins.get().getItem(jobName);
             if (job == null) {
                 rsp.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;


### PR DESCRIPTION

- issue #176
fixed deprecation warnings for findings:
- getInstance() in jenkins.model.Jenkins has been deprecated
- getActiveInstance() in jenkins.model.Jenkins has been deprecated

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
