### PR TITLE
Migrate from EE 8 to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.7</version>
     <relativePath />
   </parent>
 
@@ -50,8 +50,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <jira-rest-client.version>5.2.7</jira-rest-client.version>
     <fugue.version>4.7.2</fugue.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3654.v237e4a_f2d8da_</version>
+        <version>3850.vb_c5319efa_e29</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -129,11 +129,11 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
      * @return
      */
     private Job initProject() {
-        if (Stapler.getCurrentRequest() == null) {
+        if (Stapler.getCurrentRequest2() == null) {
             return null;
         }
 
-        List<Ancestor> ancestors = Stapler.getCurrentRequest().getAncestors();
+        List<Ancestor> ancestors = Stapler.getCurrentRequest2().getAncestors();
         for (Ancestor ancestor : ancestors) {
             if (ancestor.getObject() instanceof AbstractProject) {
                 return (AbstractProject) ancestor.getObject();

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -81,7 +81,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
@@ -157,7 +157,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
      * @return
      */
     private @CheckForNull AbstractProject getJobName() {
-        StaplerRequest currentRequest = Stapler.getCurrentRequest();
+        StaplerRequest2 currentRequest = Stapler.getCurrentRequest2();
         return currentRequest != null ? currentRequest.findAncestorObject(AbstractProject.class) : null;
     }
 
@@ -229,9 +229,9 @@ public class JiraTestDataPublisher extends TestDataPublisher {
                 .withConfigs(Util.fixNull(configs))
                 .build();
 
-        if (Stapler.getCurrentRequest() != null) {
+        if (Stapler.getCurrentRequest2() != null) {
             // classic job - e.g. Freestyle project, Matrix project, etc.
-            AbstractProject project = Stapler.getCurrentRequest().findAncestorObject(AbstractProject.class);
+            AbstractProject project = Stapler.getCurrentRequest2().findAncestorObject(AbstractProject.class);
             TestToIssueMapping.getInstance().register(project);
             JobConfigMapping.getInstance().saveConfig(project, getJobConfig());
         } else {
@@ -585,7 +585,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
          * @throws FormException
          */
         @Override
-        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
 
             try {
                 jiraUri = new URI(json.getString("jiraUrl"));
@@ -660,7 +660,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
          * @throws FormException
          */
         @Override
-        public TestDataPublisher newInstance(StaplerRequest req, JSONObject json) throws FormException {
+        public TestDataPublisher newInstance(StaplerRequest2 req, JSONObject json) throws FormException {
             String projectKey = json.getString("projectKey");
             String issueType = json.getString("issueType");
             metadataCache.removeCacheEntry(projectKey, issueType);
@@ -787,7 +787,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         @JavaScriptMethod
         public FormValidation validateFieldConfigs(String jsonForm) throws FormException {
             // extracting the configurations for associated with this plugin (we receive the entire form)
-            StaplerRequest req = Stapler.getCurrentRequest();
+            StaplerRequest2 req = Stapler.getCurrentRequest2();
             JSONObject jsonObject = JSONObject.fromObject(jsonForm);
             JSONObject publishers = jsonObject.getJSONObject("publisher");
             JSONObject jiraPublisherJSON = null;

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/api/TestToIssueMappingApi.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/api/TestToIssueMappingApi.java
@@ -7,13 +7,13 @@ import hudson.matrix.MatrixProject;
 import hudson.model.Api;
 import hudson.model.Item;
 import hudson.model.Job;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
 import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.JiraTestResultReporter.TestToIssueMapping;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  * Created by tuicu on 12/08/16.
@@ -31,7 +31,7 @@ public class TestToIssueMappingApi extends Api {
     }
 
     @Override
-    public void doJson(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+    public void doJson(StaplerRequest2 req, StaplerResponse2 rsp) throws IOException, ServletException {
         String jobName = req.getParameter("job");
         JsonElement result;
 


### PR DESCRIPTION
Migrate from deprecated EE 8 methods to non-deprecated EE 9 equivalents.

### Testing done

`mvn clean verify`