### PR TITLE
validateFieldConfigs json changed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <jira-rest-client.version>6.0.1</jira-rest-client.version>
-    <fugue.version>6.1.2</fugue.version>
+    <jira-rest-client.version>5.2.8-platform7-12284590</jira-rest-client.version>
+    <fugue.version>4.7.2</fugue.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotbugs.threshold>High</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -72,6 +72,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.JiraTestResultReporter.config.AbstractFields;
@@ -802,7 +804,29 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             // extracting the configurations for associated with this plugin (we receive the entire form)
             StaplerRequest2 req = Stapler.getCurrentRequest2();
             JSONObject jsonObject = JSONObject.fromObject(jsonForm);
-            JSONObject publishers = jsonObject.getJSONObject("publisher");
+            JSONObject publishers = null;
+            try {
+                publishers = jsonObject.getJSONObject("publisher");
+            } catch (JSONException e) {
+                JiraUtils.log("Error finding key publisher, try with array as format changed");
+                JSONArray publisherArray = jsonObject.getJSONArray("publisher");
+                //find the first array element which contains testDataPublishers 
+                for(int i = 0; i < publisherArray.size(); i++)
+                {
+                    JSONObject arrayObject = publisherArray.getJSONObject(i);
+                    for (Object o : arrayObject.keySet()) {
+                        if (o.toString().equals("testDataPublishers")) {
+                            publishers = arrayObject;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (publishers == null) {
+                return FormValidation.error("publisher object not found in json.\n");
+            }
+
             JSONObject jiraPublisherJSON = null;
 
             for (Object o : publishers.keySet()) {
@@ -821,7 +845,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
                     newInstancesFromHeteroList(req, jiraPublisherJSON.get("configs"), getListDescriptors());
             if (configs == null) {
                 // nothing to validate
-                return FormValidation.ok("OK!");
+                return FormValidation.ok("OK! No validation done.");
             }
             String projectKey = jiraPublisherJSON.getString("projectKey");
             Long issueType = jiraPublisherJSON.getLong("issueType");

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -810,9 +810,8 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             } catch (JSONException e) {
                 JiraUtils.log("Error finding key publisher, try with array as format changed");
                 JSONArray publisherArray = jsonObject.getJSONArray("publisher");
-                //find the first array element which contains testDataPublishers 
-                for(int i = 0; i < publisherArray.size(); i++)
-                {
+                // find the first array element which contains testDataPublishers
+                for (int i = 0; i < publisherArray.size(); i++) {
                     JSONObject arrayObject = publisherArray.getJSONObject(i);
                     for (Object o : arrayObject.keySet()) {
                         if (o.toString().equals("testDataPublishers")) {

--- a/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/config/StringArrayFields/help-value.html
+++ b/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/config/StringArrayFields/help-value.html
@@ -25,5 +25,5 @@
     <p>BUILD_RESULT</p>
 
     <h3>WARNING: Your input will not be validated against the server's metadata. Check Jira to make sure you insert
-    a valid value for this field and use the Validate Fields button bellow, otherwise the plugin will fail to create your issue.</h3>
+    a valid value for this field and use the Validate Fields button below, otherwise the plugin will fail to create your issue.</h3>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/config/StringFields/help-value.html
+++ b/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/config/StringFields/help-value.html
@@ -25,5 +25,5 @@
     <p>BUILD_RESULT</p>
 
     <h3>WARNING: Your input will not be validated against the server's metadata. Check Jira to make sure you insert
-    a valid value for this field and use the Validate Fields button bellow, otherwise the plugin will fail to create your issue.</h3>
+    a valid value for this field and use the Validate Fields button below, otherwise the plugin will fail to create your issue.</h3>
 </div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
- json returned from validateFieldConfigs changed,  added an adaptation to support as fallback also JSONArray as type for publisher 
- fixed typo bellow -> below
- fix build issue by going back to previous versions
```
21:28:39  [ERROR] Failed to execute goal on project JiraTestResultReporter: Could not collect dependencies for project org.jenkins-ci.plugins:JiraTestResultReporter:hpi:269.v2994cd1ed4e6
21:28:39  [ERROR] Failed to read artifact descriptor for com.atlassian.jira:jira-rest-java-client-api:jar:6.0.1
21:28:39  [ERROR] 	Caused by: The following artifacts could not be resolved: com.atlassian.jira:jira-rest-java-client-api:pom:6.0.1 (absent): Could not transfer artifact com.atlassian.jira:jira-rest-java-client-api:pom:6.0.1 from/to aws-eks-internal (http://artifact-caching-proxy.artifact-caching-proxy.svc.cluster.local:8080/): status code: 401, reason phrase:  (401)
21:28:39  [ERROR] Failed to read artifact descriptor for com.atlassian.jira:jira-rest-java-client-core:jar:6.0.1
21:28:39  [ERROR] 	Caused by: The following artifacts could not be resolved: com.atlassian.jira:jira-rest-java-client-core:pom:6.0.1 (absent): Could not transfer artifact com.atlassian.jira:jira-rest-java-client-core:pom:6.0.1 from/to aws-eks-internal (http://artifact-caching-proxy.artifact-caching-proxy.svc.cluster.local:8080/): status code: 401, reason phrase:  (401)
21:28:39  [ERROR] Failed to read artifact descriptor for io.atlassian.fugue:fugue:jar:6.1.2
21:28:39  [ERROR] 	Caused by: The following artifacts could not be resolved: com.atlassian.pom:central-pom:pom:5.0.29 (absent): Could not transfer artifact com.atlassian.pom:central-pom:pom:5.0.29 from/to aws-eks-internal (http://artifact-caching-proxy.artifact-caching-proxy.svc.cluster.local:8080/): status code: 401, reason phrase:  (401)

```
reverting:
Bump io.atlassian.fugue:fugue from 4.7.2 to 6.1.2 (https://github.com/jenkinsci/JiraTestResultReporter-plugin/pull/209) https://github.com/dependabot[bot]
Bump jira-rest-client.version from 5.2.6 to 6.0.1 (https://github.com/jenkinsci/JiraTestResultReporter-plugin/pull/152) https://github.com/dependabot[bot]

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
