### PR TITLE
Update /search API usage due to deprecation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
-  [platform: 'windows', jdk: 17],
+  [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,8 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <jira-rest-client.version>6.0.2</jira-rest-client.version>
+    <maven.compiler.release>21</maven.compiler.release>
+    <jira-rest-client.version>7.0.1</jira-rest-client.version>
     <fugue.version>6.1.2</fugue.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotbugs.threshold>High</spotbugs.threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,7 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <maven.compiler.release>21</maven.compiler.release>
-    <jira-rest-client.version>7.0.1</jira-rest-client.version>
+    <jira-rest-client.version>6.0.2</jira-rest-client.version>
     <fugue.version>6.1.2</fugue.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotbugs.threshold>High</spotbugs.threshold>

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -342,7 +342,7 @@ public class JiraUtils {
         JiraUtils.log(jql);
 
         Promise<SearchResult> searchJqlPromise =
-                JiraUtils.getJiraDescriptor().getRestClient().getSearchClient().searchJql(jql, 50, 0, fields);
+                JiraUtils.getJiraDescriptor().getRestClient().getSearchClient().searchJql(jql, 50, null, fields);
         return searchJqlPromise.claim();
     }
 

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -166,7 +166,7 @@ public class JiraUtils {
             }
             IssueInput issueInput = JiraUtils.createIssueInput(project, test, envVars, trigger);
             SearchResult searchResult = JiraUtils.findIssues(project, test, envVars, issueInput);
-            if (searchResult != null && searchResult.getTotal() > 0) {
+            if (searchResult != null) {
                 boolean duplicate = false;
                 FieldInput fi = JiraTestDataPublisher.JiraTestDataPublisherDescriptor.templates
                         .get(0)
@@ -212,7 +212,7 @@ public class JiraUtils {
             if (!JobConfigMapping.getInstance().getManualAddIssue(job)) {
                 IssueInput issueInput = JiraUtils.createIssueInput(job, test, envVars, JiraIssueTrigger.JOB);
                 SearchResult searchResult = JiraUtils.findIssues(job, test, envVars, issueInput);
-                if (searchResult != null && searchResult.getTotal() > 0) {
+                if (searchResult != null) {
                     for (Issue issue : searchResult.getIssues()) {
                         issueKeys.add(issue.getKey());
                     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
- Updates /search API usage due to deprecation announced on https://developer.atlassian.com/changelog/#CHANGE-2046, main  important changes:
    - Response will no longer contain the fields: `expand`, `startAt`, `maxResults`, `total`
    - Response got new fields: `nextPageToken` and `isLast`
- Mainly we skip the use of the deprecated `startAt` parameter on the REST API request for the search operation and remove the use of `total` on the search result.
- Before this PR:
```
RestClientException{statusCode=Optional.of(410), errorCollections=[ErrorCollection{status=410, errors={}, errorMessages=[The requested API has been removed. Please migrate to the /rest/api/3/search/jql API. A full migration guideline is available at https://developer.atlassian.com/changelog/#CHANGE-2046]}]}
	at PluginClassLoader for JiraTestResultReporter//com.atlassian.jira.rest.client.internal.async.DelegatingPromise.claim(DelegatingPromise.java:45)
	at PluginClassLoader for JiraTestResultReporter//org.jenkinsci.plugins.JiraTestResultReporter.JiraUtils.getSearchResult(JiraUtils.java:338)
```

### Testing done

- Tested locally and able to create new issues without facing the REST exception on the deprecated API
```
2025-09-04 14:20:50.917+0000 [id=981]	INFO	o.j.p.J.JiraUtils#log: No map found for job test
2025-09-04 14:20:50.921+0000 [id=981]	INFO	o.j.p.J.JiraUtils#log: No configs found for project test
2025-09-04 14:20:50.935+0000 [id=981]	INFO	o.j.p.J.JiraUtils#log: resolution = "unresolved" and project = "ABC" and text ~ "test.OtherTest.mytestOther : oops"
2025-09-04 14:20:57.419+0000 [id=981]	INFO	o.j.p.J.JiraUtils#log: resolution = "unresolved" and project = "ABC" and text ~ "test.SomeTest.test3o : oops"
2025-09-04 14:21:02.906+0000 [id=981]	INFO	o.j.p.J.JiraUtils#log: resolution = "unresolved" and project = "ABC" and text ~ "test.SomeTest.test4o : oops"
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
