### PR TITLE
Remove getTotal request due to /search API deprecation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -140,7 +140,7 @@ public class JiraUtils {
         }
 
         SearchResult searchResult = JiraUtils.findUnresolvedJiraIssues(String.join(",", jiraIds));
-        if (searchResult != null && searchResult.getTotal() > 0) {
+        if (searchResult != null) {
             for (Issue issue : searchResult.getIssues()) {
                 String testKey = issue.getKey();
                 String testId = keysToCheck.get(testKey);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
### Highlights
- Missed from https://github.com/jenkinsci/JiraTestResultReporter-plugin/pull/258

### Testing done
- Before the PR:
```
java.lang.UnsupportedOperationException: Total is not available in the Cloud version of the new Search API response. Please use `SearchRestClient.totalCount` instead to fetch the estimated count of the issues for a given JQL.
	at PluginClassLoader for JiraTestResultReporter//com.atlassian.jira.rest.client.api.domain.SearchResult.getTotal(SearchResult.java:80)
	at PluginClassLoader for JiraTestResultReporter//org.jenkinsci.plugins.JiraTestResultReporter.JiraUtils.cleanJobCacheFile(JiraUtils.java:143)
```
- After the PR the cleanup of the job cache file is done.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
