### PR TITLE
Bugfix on duplicated issues search operation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -366,7 +366,6 @@ public class JiraUtils {
         String result = jql.replace("'", "\\'")
                 .replace("\"", "\\\"")
                 .replace("\\+", "\\\\+")
-                .replace("-", "\\\\-")
                 .replace("&", "\\\\&")
                 .replace("\\|", "\\\\|")
                 .replace("~", "\\\\~")


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
### Highlights
- Recent changes on the search API made the JQL being able to deal now with special char `-` 

### Testing done
- Tested with a simple Java main method
```java
public static void main(String[] args) throws URISyntaxException {
    	AsynchronousJiraRestClientFactory factory = new AsynchronousJiraRestClientFactory();
    	JiraRestClient restClient = factory.createWithBasicHttpAuthentication(new URI("my-url"), "my-user", "my-pwd");
        String jql = String.format(
                "resolution = \"unresolved\" and project = \"%s\" and text ~ \"%s\"",
                "BEE", escapeJQL("Test failure - foo-bar/integration.bats.foo-bar rolling upgrade"));
    	
    	Set<String> fields = new HashSet<>();
        fields.add("issueKey");
        fields.add("summary");
        fields.add("issuetype");
        fields.add("created");
        fields.add("updated");
        fields.add("project");
        fields.add("status");
        
        Promise<SearchResult> searchJqlPromise = restClient.getSearchClient().searchJql(jql, 50, null, fields);
        SearchResult searchJqResult = searchJqlPromise.claim();
        searchJqResult.getIssues();
}
```
- Before this PR when we use the REST search API client asking for issues with `-` provided no values
- After this PR it works as expected, example: 
```
[Issue{self=https://my-url/rest/api/latest/issue/592015, key=ABC62738, id=592015, project=BasicProject{self=https://my-url/rest/api/2/project/13699, key=ABC, id=13699, name=Foo Project}, 
[...]
Issue{self=https://my-url/rest/api/latest/issue/591939, key=ABC62726, id=591939, project=BasicProject{self=https://my-url/rest/api/2/project/13699, key=ABC, id=13699, name=Foo Project}, 
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
