### PR TITLE
try to fix issues from Commons Lang 2 ban just visible now

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -33,7 +33,7 @@ import io.atlassian.util.concurrent.Promise;
 import java.util.Collections;
 import java.util.List;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.JiraTestResultReporter.restclientextensions.FullStatus;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;

--- a/src/test/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataTest.java
+++ b/src/test/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataTest.java
@@ -7,7 +7,7 @@ import hudson.tasks.junit.TestResult;
 import hudson.tasks.test.PipelineTestDetails;
 import hudson.tasks.test.TestObject;
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
From https://github.com/jenkinsci/JiraTestResultReporter-plugin/pull/277/checks?check_run_id=64575310809

```
2026-02-23T18:47:56.230Z] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.6.2:enforce (check-commons-lang-imports) on project JiraTestResultReporter: [2026-02-23T18:47:56.230Z] [ERROR] Rule 0: org.apache.maven.plugins.enforcer.RestrictImports failed with message: [2026-02-23T18:47:56.230Z] [ERROR]
[2026-02-23T18:47:56.231Z] [ERROR] Banned imports detected: [2026-02-23T18:47:56.231Z] [ERROR]
[2026-02-23T18:47:56.231Z] [ERROR] Reason: Use Commons Lang 2 (org.apache.commons.lang.*) [2026-02-23T18:47:56.231Z] [ERROR] 	in file:///home/jenkins/agent/workspace/TestResultReporter-plugin_PR-277/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java [2026-02-23T18:47:56.231Z] [ERROR] 		org.apache.commons.lang.StringUtils 	(Line: 36, Matched by: org.apache.commons.lang.**) [2026-02-23T18:47:56.231Z] [ERROR]
[2026-02-23T18:47:56.231Z] [ERROR] Banned imports detected in TEST code: [2026-02-23T18:47:56.231Z] [ERROR]
[2026-02-23T18:47:56.231Z] [ERROR] Reason: Use Commons Lang 2 (org.apache.commons.lang.*) [2026-02-23T18:47:56.231Z] [ERROR] 	in file:///home/jenkins/agent/workspace/TestResultReporter-plugin_PR-277/src/test/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataTest.java [2026-02-23T18:47:56.232Z] [ERROR] 		org.apache.commons.lang.StringUtils 	(Line: 10, Matched by: org.apache.commons.lang.**)
```

by using v3, maybe even better would be using plain java, see https://github.com/openrewrite/rewrite-apache/issues/7

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

