### PR TITLE
Use scoped API endpoint and browsable URL and upgrade to use the latest jira-rest-client version adapted for v3 API endpoints + Java 21 upgrade

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,4 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Pjava-level-21
 -Dchangelist.format=%d.v%s

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 17],
   [platform: 'linux', jdk: 21],
   [platform: 'linux', jdk: 25],
   [platform: 'windows', jdk: 21],

--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,9 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.baseline>2.504</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-    <jira-rest-client.version>6.0.2</jira-rest-client.version>
+    <jira-rest-client.version>7.0.1</jira-rest-client.version>
     <fugue.version>6.1.4</fugue.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotbugs.threshold>High</spotbugs.threshold>
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5054.v620b_5d2b_d5e6</version>
+        <version>5983.v443959746f1f</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -159,7 +159,7 @@
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpmime</artifactId>
         </exclusion>
-        <!-- Provided by jersey2-api plugin -->
+        <!-- Provided by jersey3-api plugin (Jakarta) -->
         <exclusion>
           <groupId>org.codehaus.jettison</groupId>
           <artifactId>jettison</artifactId>
@@ -209,7 +209,8 @@
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
-      <artifactId>jersey2-api</artifactId>
+      <artifactId>jersey3-api</artifactId>
+      <version>3.1.11-4.v77818819c2e1</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -163,7 +163,7 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
      * @return
      */
     public String getIssueUrl() {
-        return JiraUtils.getIssueURL(JiraUtils.getJiraDescriptor().getJiraUrl(), issueKey);
+        return JiraUtils.getIssueURL(JiraUtils.getJiraDescriptor().getjiraBrowsableUrl(), issueKey);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestAction.java
@@ -163,7 +163,7 @@ public class JiraTestAction extends TestAction implements ExtensionPoint, Descri
      * @return
      */
     public String getIssueUrl() {
-        return JiraUtils.getIssueURL(JiraUtils.getJiraDescriptor().getjiraBrowsableUrl(), issueKey);
+        return JiraUtils.getIssueURL(JiraUtils.getJiraDescriptor().getJiraBrowsableUrl(), issueKey);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -471,7 +471,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
      * @return
      */
     public String getJiraUrl() {
-        return getDescriptor().getjiraUrl();
+        return getDescriptor().getJiraUrl();
     }
 
     /**
@@ -514,7 +514,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         private transient JiraRestClient restClient;
         private transient JiraRestClientExtension restClientExtension;
         private transient MetadataCache metadataCache = new MetadataCache();
-        private URI jiraApiUri = null;
+        private URI jiraUri = null;
         private URI jiraBrowsableUri = null;
         private String username = null;
         private Secret password = null;
@@ -522,8 +522,8 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         private String defaultSummary;
         private String defaultDescription;
 
-        public URI getJiraApiUri() {
-            return jiraApiUri;
+        public URI getJiraUri() {
+            return jiraUri;
         }
 
         public URI getJiraBrowsableUri() {
@@ -543,7 +543,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         }
 
         public String getJiraUrl() {
-            return jiraApiUri != null ? jiraApiUri.toString() : null;
+            return jiraUri != null ? jiraUri.toString() : null;
         }
 
         public String getJiraBrowsableUrl() {
@@ -596,23 +596,23 @@ public class JiraTestDataPublisher extends TestDataPublisher {
          * @return this object
          */
         public Object readResolve() {
-            if (jiraApiUri != null && username != null && password != null) {
+            if (jiraUri != null && username != null && password != null) {
                 AsynchronousJiraRestClientFactory factory = new AsynchronousJiraRestClientFactory();
                 if (useBearerAuth) {
                     BearerAuthenticationHandler handler = new BearerAuthenticationHandler(password.getPlainText());
-                    restClient = factory.create(jiraApiUri, handler);
+                    restClient = factory.create(jiraUri, handler);
 
                     restClientExtension = new JiraRestClientExtension(
-                            jiraApiUri,
+                            jiraUri,
                             new AsynchronousHttpClientFactory()
-                                    .createClient(jiraApiUri, new BearerAuthenticationHandler(password.getPlainText())));
+                                    .createClient(jiraUri, new BearerAuthenticationHandler(password.getPlainText())));
                 } else {
-                    restClient = factory.createWithBasicHttpAuthentication(jiraApiUri, username, password.getPlainText());
+                    restClient = factory.createWithBasicHttpAuthentication(jiraUri, username, password.getPlainText());
                     restClientExtension = new JiraRestClientExtension(
-                            jiraApiUri,
+                            jiraUri,
                             new AsynchronousHttpClientFactory()
                                     .createClient(
-                                            jiraApiUri,
+                                            jiraUri,
                                             new BasicHttpAuthenticationHandler(username, password.getPlainText())));
                 }
                 tryCreatingStatusToCategoryMap();
@@ -640,7 +640,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
 
             try {
-                jiraApiUri = new URI(json.getString("jiraUrl"));
+                jiraUri = new URI(json.getString("jiraUrl"));
                 if (json.getString("jiraBrowsableUrl") != null) {
                     jiraBrowsableUri = new URI(json.getString("jiraBrowsableUrl"));
                 } else {
@@ -669,19 +669,19 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             AsynchronousJiraRestClientFactory factory = new AsynchronousJiraRestClientFactory();
             if (useBearerAuth) {
                 BearerAuthenticationHandler handler = new BearerAuthenticationHandler(password.getPlainText());
-                restClient = factory.create(jiraApiUri, handler);
+                restClient = factory.create(jiraUri, handler);
 
                 restClientExtension = new JiraRestClientExtension(
-                        jiraApiUri,
+                        jiraUri,
                         new AsynchronousHttpClientFactory()
-                                .createClient(jiraApiUri, new BearerAuthenticationHandler(password.getPlainText())));
+                                .createClient(jiraUri, new BearerAuthenticationHandler(password.getPlainText())));
             } else {
-                restClient = factory.createWithBasicHttpAuthentication(jiraApiUri, username, password.getPlainText());
+                restClient = factory.createWithBasicHttpAuthentication(jiraUri, username, password.getPlainText());
                 restClientExtension = new JiraRestClientExtension(
-                        jiraApiUri,
+                        jiraUri,
                         new AsynchronousHttpClientFactory()
                                 .createClient(
-                                        jiraApiUri,
+                                        jiraUri,
                                         new BasicHttpAuthenticationHandler(username, password.getPlainText())));
             }
             tryCreatingStatusToCategoryMap();

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -467,11 +467,19 @@ public class JiraTestDataPublisher extends TestDataPublisher {
     }
 
     /**
-     * Getter for the jira url, called from config.jelly to determine if the global configurations were done
+     * Getter for the jira API url, called from config.jelly to determine if the global configurations were done
      * @return
      */
-    public String getJiraUrl() {
-        return getDescriptor().getJiraUrl();
+    public String getjiraApiUrl() {
+        return getDescriptor().getjiraApiUrl();
+    }
+
+    /**
+     * Getter for the jira browsable url, called from config.jelly to determine if the global configurations were done
+     * @return
+     */
+    public String getjiraBrowsableUrl() {
+        return getDescriptor().getjiraBrowsableUrl();
     }
 
     @Symbol("jiraTestResultReporter")
@@ -506,15 +514,20 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         private transient JiraRestClient restClient;
         private transient JiraRestClientExtension restClientExtension;
         private transient MetadataCache metadataCache = new MetadataCache();
-        private URI jiraUri = null;
+        private URI jiraApiUri = null;
+        private URI jiraBrowsableUri = null;
         private String username = null;
         private Secret password = null;
         private boolean useBearerAuth = false;
         private String defaultSummary;
         private String defaultDescription;
 
-        public URI getJiraUri() {
-            return jiraUri;
+        public URI getjiraApiUri() {
+            return jiraApiUri;
+        }
+
+        public URI getjiraBrowsableUri() {
+            return jiraBrowsableUri;
         }
 
         public String getUsername() {
@@ -529,8 +542,12 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             return useBearerAuth;
         }
 
-        public String getJiraUrl() {
-            return jiraUri != null ? jiraUri.toString() : null;
+        public String getjiraApiUrl() {
+            return jiraApiUri != null ? jiraApiUri.toString() : null;
+        }
+
+        public String getjiraBrowsableUrl() {
+            return jiraBrowsableUri != null ? jiraBrowsableUri.toString() : null;
         }
 
         public JiraRestClient getRestClient() {
@@ -579,23 +596,23 @@ public class JiraTestDataPublisher extends TestDataPublisher {
          * @return this object
          */
         public Object readResolve() {
-            if (jiraUri != null && username != null && password != null) {
+            if (jiraApiUri != null && username != null && password != null) {
                 AsynchronousJiraRestClientFactory factory = new AsynchronousJiraRestClientFactory();
                 if (useBearerAuth) {
                     BearerAuthenticationHandler handler = new BearerAuthenticationHandler(password.getPlainText());
-                    restClient = factory.create(jiraUri, handler);
+                    restClient = factory.create(jiraApiUri, handler);
 
                     restClientExtension = new JiraRestClientExtension(
-                            jiraUri,
+                            jiraApiUri,
                             new AsynchronousHttpClientFactory()
-                                    .createClient(jiraUri, new BearerAuthenticationHandler(password.getPlainText())));
+                                    .createClient(jiraApiUri, new BearerAuthenticationHandler(password.getPlainText())));
                 } else {
-                    restClient = factory.createWithBasicHttpAuthentication(jiraUri, username, password.getPlainText());
+                    restClient = factory.createWithBasicHttpAuthentication(jiraApiUri, username, password.getPlainText());
                     restClientExtension = new JiraRestClientExtension(
-                            jiraUri,
+                            jiraApiUri,
                             new AsynchronousHttpClientFactory()
                                     .createClient(
-                                            jiraUri,
+                                            jiraApiUri,
                                             new BasicHttpAuthenticationHandler(username, password.getPlainText())));
                 }
                 tryCreatingStatusToCategoryMap();
@@ -623,7 +640,12 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
 
             try {
-                jiraUri = new URI(json.getString("jiraUrl"));
+                jiraApiUri = new URI(json.getString("jiraApiUrl"));
+                if (json.getString("jiraBrowsableUrl") != null) {
+                    jiraBrowsableUri = new URI(json.getString("jiraBrowsableUrl"));
+                } else {
+                    jiraBrowsableUri = new URI(json.getString("jiraApiUrl"));
+                }
             } catch (URISyntaxException e) {
                 JiraUtils.logError("Invalid server URI", e);
             }
@@ -634,7 +656,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             defaultSummary = json.getString("summary");
             defaultDescription = json.getString("description");
 
-            if (json.getString("jiraUrl").equals("")
+            if (json.getString("jiraApiUrl").equals("")
                     || json.getString("username").equals("")
                     || json.getString("password").equals("")) {
                 useBearerAuth = false;
@@ -647,19 +669,19 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             AsynchronousJiraRestClientFactory factory = new AsynchronousJiraRestClientFactory();
             if (useBearerAuth) {
                 BearerAuthenticationHandler handler = new BearerAuthenticationHandler(password.getPlainText());
-                restClient = factory.create(jiraUri, handler);
+                restClient = factory.create(jiraApiUri, handler);
 
                 restClientExtension = new JiraRestClientExtension(
-                        jiraUri,
+                        jiraApiUri,
                         new AsynchronousHttpClientFactory()
-                                .createClient(jiraUri, new BearerAuthenticationHandler(password.getPlainText())));
+                                .createClient(jiraApiUri, new BearerAuthenticationHandler(password.getPlainText())));
             } else {
-                restClient = factory.createWithBasicHttpAuthentication(jiraUri, username, password.getPlainText());
+                restClient = factory.createWithBasicHttpAuthentication(jiraApiUri, username, password.getPlainText());
                 restClientExtension = new JiraRestClientExtension(
-                        jiraUri,
+                        jiraApiUri,
                         new AsynchronousHttpClientFactory()
                                 .createClient(
-                                        jiraUri,
+                                        jiraApiUri,
                                         new BasicHttpAuthenticationHandler(username, password.getPlainText())));
             }
             tryCreatingStatusToCategoryMap();
@@ -704,7 +726,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
 
         /**
          * Validation for the global configuration, called when Validate Settings is clicked (global.jelly)
-         * @param jiraUrl
+         * @param jiraApiUrl
          * @param username
          * @param password
          * @param useBearerAuth
@@ -712,7 +734,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
          */
         @RequirePOST
         public FormValidation doValidateGlobal(
-                @QueryParameter String jiraUrl,
+                @QueryParameter String jiraApiUrl,
                 @QueryParameter String username,
                 @QueryParameter String password,
                 @QueryParameter boolean useBearerAuth) {
@@ -721,8 +743,8 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             String serverName;
             try {
                 // implicit URL validation check
-                new URL(jiraUrl);
-                URI uri = new URI(jiraUrl);
+                new URL(jiraApiUrl);
+                URI uri = new URI(jiraApiUrl);
                 if (uri == null) {
                     return FormValidation.error("Invalid URL");
                 }

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -470,8 +470,8 @@ public class JiraTestDataPublisher extends TestDataPublisher {
      * Getter for the jira API url, called from config.jelly to determine if the global configurations were done
      * @return
      */
-    public String getJiraApiUrl() {
-        return getDescriptor().getJiraApiUrl();
+    public String getJiraUrl() {
+        return getDescriptor().getjiraUrl();
     }
 
     /**
@@ -542,7 +542,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             return useBearerAuth;
         }
 
-        public String getJiraApiUrl() {
+        public String getJiraUrl() {
             return jiraApiUri != null ? jiraApiUri.toString() : null;
         }
 
@@ -640,11 +640,11 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         public boolean configure(StaplerRequest2 req, JSONObject json) throws FormException {
 
             try {
-                jiraApiUri = new URI(json.getString("jiraApiUrl"));
+                jiraApiUri = new URI(json.getString("jiraUrl"));
                 if (json.getString("jiraBrowsableUrl") != null) {
                     jiraBrowsableUri = new URI(json.getString("jiraBrowsableUrl"));
                 } else {
-                    jiraBrowsableUri = new URI(json.getString("jiraApiUrl"));
+                    jiraBrowsableUri = new URI(json.getString("jiraUrl"));
                 }
             } catch (URISyntaxException e) {
                 JiraUtils.logError("Invalid server URI", e);
@@ -656,7 +656,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             defaultSummary = json.getString("summary");
             defaultDescription = json.getString("description");
 
-            if (json.getString("jiraApiUrl").equals("")
+            if (json.getString("jiraUrl").equals("")
                     || json.getString("username").equals("")
                     || json.getString("password").equals("")) {
                 useBearerAuth = false;
@@ -726,7 +726,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
 
         /**
          * Validation for the global configuration, called when Validate Settings is clicked (global.jelly)
-         * @param jiraApiUrl
+         * @param jiraUrl
          * @param username
          * @param password
          * @param useBearerAuth
@@ -734,7 +734,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
          */
         @RequirePOST
         public FormValidation doValidateGlobal(
-                @QueryParameter String jiraApiUrl,
+                @QueryParameter String jiraUrl,
                 @QueryParameter String username,
                 @QueryParameter String password,
                 @QueryParameter boolean useBearerAuth) {
@@ -743,8 +743,8 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             String serverName;
             try {
                 // implicit URL validation check
-                new URL(jiraApiUrl);
-                URI uri = new URI(jiraApiUrl);
+                new URL(jiraUrl);
+                URI uri = new URI(jiraUrl);
                 if (uri == null) {
                     return FormValidation.error("Invalid URL");
                 }

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -470,7 +470,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
      * Getter for the jira API url, called from config.jelly to determine if the global configurations were done
      * @return
      */
-    public String getjiraApiUrl() {
+    public String getJiraApiUrl() {
         return getDescriptor().getjiraApiUrl();
     }
 
@@ -478,7 +478,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
      * Getter for the jira browsable url, called from config.jelly to determine if the global configurations were done
      * @return
      */
-    public String getjiraBrowsableUrl() {
+    public String getJiraBrowsableUrl() {
         return getDescriptor().getjiraBrowsableUrl();
     }
 
@@ -522,11 +522,11 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         private String defaultSummary;
         private String defaultDescription;
 
-        public URI getjiraApiUri() {
+        public URI getJiraApiUri() {
             return jiraApiUri;
         }
 
-        public URI getjiraBrowsableUri() {
+        public URI getJiraBrowsableUri() {
             return jiraBrowsableUri;
         }
 
@@ -542,11 +542,11 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             return useBearerAuth;
         }
 
-        public String getjiraApiUrl() {
+        public String getJiraApiUrl() {
             return jiraApiUri != null ? jiraApiUri.toString() : null;
         }
 
-        public String getjiraBrowsableUrl() {
+        public String getJiraBrowsableUrl() {
             return jiraBrowsableUri != null ? jiraBrowsableUri.toString() : null;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -471,7 +471,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
      * @return
      */
     public String getJiraApiUrl() {
-        return getDescriptor().getjiraApiUrl();
+        return getDescriptor().getJiraApiUrl();
     }
 
     /**
@@ -479,7 +479,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
      * @return
      */
     public String getJiraBrowsableUrl() {
-        return getDescriptor().getjiraBrowsableUrl();
+        return getDescriptor().getJiraBrowsableUrl();
     }
 
     @Symbol("jiraTestResultReporter")

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -19,7 +19,6 @@ import com.atlassian.httpclient.api.ResponseTransformationException;
 import com.atlassian.httpclient.api.UnexpectedResponseException;
 import com.atlassian.jira.rest.client.api.IssueRestClient;
 import com.atlassian.jira.rest.client.api.JiraRestClient;
-import com.atlassian.jira.rest.client.api.MetadataRestClient;
 import com.atlassian.jira.rest.client.api.OptionalIterable;
 import com.atlassian.jira.rest.client.api.ProjectRestClient;
 import com.atlassian.jira.rest.client.api.RestClientException;
@@ -27,14 +26,12 @@ import com.atlassian.jira.rest.client.api.domain.BasicIssue;
 import com.atlassian.jira.rest.client.api.domain.Issue;
 import com.atlassian.jira.rest.client.api.domain.IssueType;
 import com.atlassian.jira.rest.client.api.domain.Project;
-import com.atlassian.jira.rest.client.api.domain.ServerInfo;
 import com.atlassian.jira.rest.client.api.domain.Transition;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInput;
 import com.atlassian.jira.rest.client.api.domain.input.IssueInputBuilder;
 import com.atlassian.jira.rest.client.api.domain.input.TransitionInput;
 import com.atlassian.jira.rest.client.auth.BasicHttpAuthenticationHandler;
 import com.atlassian.jira.rest.client.internal.async.AsynchronousHttpClientFactory;
-import com.atlassian.jira.rest.client.internal.async.AsynchronousJiraRestClientFactory;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.DescriptorExtensionList;
@@ -78,6 +75,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.JiraTestResultReporter.config.AbstractFields;
 import org.jenkinsci.plugins.JiraTestResultReporter.config.StringFields;
+import org.jenkinsci.plugins.JiraTestResultReporter.restclientextensions.AsynchronousJiraRestClientV3;
 import org.jenkinsci.plugins.JiraTestResultReporter.restclientextensions.FullStatus;
 import org.jenkinsci.plugins.JiraTestResultReporter.restclientextensions.JiraRestClientExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -597,23 +595,21 @@ public class JiraTestDataPublisher extends TestDataPublisher {
          */
         public Object readResolve() {
             if (jiraUri != null && username != null && password != null) {
-                AsynchronousJiraRestClientFactory factory = new AsynchronousJiraRestClientFactory();
+                AsynchronousHttpClientFactory httpClientFactory = new AsynchronousHttpClientFactory();
                 if (useBearerAuth) {
                     BearerAuthenticationHandler handler = new BearerAuthenticationHandler(password.getPlainText());
-                    restClient = factory.create(jiraUri, handler);
+                    restClient =
+                            new AsynchronousJiraRestClientV3(jiraUri, httpClientFactory.createClient(jiraUri, handler));
 
-                    restClientExtension = new JiraRestClientExtension(
-                            jiraUri,
-                            new AsynchronousHttpClientFactory()
-                                    .createClient(jiraUri, new BearerAuthenticationHandler(password.getPlainText())));
+                    restClientExtension =
+                            new JiraRestClientExtension(jiraUri, httpClientFactory.createClient(jiraUri, handler));
                 } else {
-                    restClient = factory.createWithBasicHttpAuthentication(jiraUri, username, password.getPlainText());
-                    restClientExtension = new JiraRestClientExtension(
-                            jiraUri,
-                            new AsynchronousHttpClientFactory()
-                                    .createClient(
-                                            jiraUri,
-                                            new BasicHttpAuthenticationHandler(username, password.getPlainText())));
+                    BasicHttpAuthenticationHandler handler =
+                            new BasicHttpAuthenticationHandler(username, password.getPlainText());
+                    restClient =
+                            new AsynchronousJiraRestClientV3(jiraUri, httpClientFactory.createClient(jiraUri, handler));
+                    restClientExtension =
+                            new JiraRestClientExtension(jiraUri, httpClientFactory.createClient(jiraUri, handler));
                 }
                 tryCreatingStatusToCategoryMap();
             }
@@ -666,23 +662,21 @@ public class JiraTestDataPublisher extends TestDataPublisher {
                 return true;
             }
 
-            AsynchronousJiraRestClientFactory factory = new AsynchronousJiraRestClientFactory();
+            AsynchronousHttpClientFactory httpClientFactory = new AsynchronousHttpClientFactory();
             if (useBearerAuth) {
                 BearerAuthenticationHandler handler = new BearerAuthenticationHandler(password.getPlainText());
-                restClient = factory.create(jiraUri, handler);
+                restClient =
+                        new AsynchronousJiraRestClientV3(jiraUri, httpClientFactory.createClient(jiraUri, handler));
 
-                restClientExtension = new JiraRestClientExtension(
-                        jiraUri,
-                        new AsynchronousHttpClientFactory()
-                                .createClient(jiraUri, new BearerAuthenticationHandler(password.getPlainText())));
+                restClientExtension =
+                        new JiraRestClientExtension(jiraUri, httpClientFactory.createClient(jiraUri, handler));
             } else {
-                restClient = factory.createWithBasicHttpAuthentication(jiraUri, username, password.getPlainText());
-                restClientExtension = new JiraRestClientExtension(
-                        jiraUri,
-                        new AsynchronousHttpClientFactory()
-                                .createClient(
-                                        jiraUri,
-                                        new BasicHttpAuthenticationHandler(username, password.getPlainText())));
+                BasicHttpAuthenticationHandler handler =
+                        new BasicHttpAuthenticationHandler(username, password.getPlainText());
+                restClient =
+                        new AsynchronousJiraRestClientV3(jiraUri, httpClientFactory.createClient(jiraUri, handler));
+                restClientExtension =
+                        new JiraRestClientExtension(jiraUri, httpClientFactory.createClient(jiraUri, handler));
             }
             tryCreatingStatusToCategoryMap();
             save();
@@ -740,7 +734,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
                 @QueryParameter boolean useBearerAuth) {
 
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-            String serverName;
+            String serverName = "Jira";
             try {
                 // implicit URL validation check
                 new URL(jiraUrl);
@@ -749,23 +743,33 @@ public class JiraTestDataPublisher extends TestDataPublisher {
                     return FormValidation.error("Invalid URL");
                 }
                 Secret pass = Secret.fromString(password);
-                // JIRA does not offer ways to validate username and password, so we try to query some server
-                // metadata, to see if the configured user is authorized on this server
-                AsynchronousJiraRestClientFactory factory = new AsynchronousJiraRestClientFactory();
+                // Validate connection by trying to access projects (API v3 compatible, lightweight)
+                AsynchronousHttpClientFactory httpClientFactory = new AsynchronousHttpClientFactory();
                 JiraRestClient restClient;
                 if (useBearerAuth) {
                     BearerAuthenticationHandler handler = new BearerAuthenticationHandler(pass.getPlainText());
-                    restClient = factory.create(uri, handler);
+                    restClient = new AsynchronousJiraRestClientV3(uri, httpClientFactory.createClient(uri, handler));
                 } else {
-                    restClient = factory.createWithBasicHttpAuthentication(uri, username, pass.getPlainText());
+                    BasicHttpAuthenticationHandler handler =
+                            new BasicHttpAuthenticationHandler(username, pass.getPlainText());
+                    restClient = new AsynchronousJiraRestClientV3(uri, httpClientFactory.createClient(uri, handler));
                 }
 
-                MetadataRestClient client = restClient.getMetadataClient();
-                Promise<ServerInfo> serverInfoPromise = client.getServerInfo();
-                ServerInfo serverInfo = serverInfoPromise.claim();
-                serverName = serverInfo.getServerTitle();
-                String serverVersion = serverInfo.getVersion();
-                JiraUtils.logError("INFO: JIRA Version" + serverVersion);
+                // Validate by getting accessible projects - proves authentication and basic permissions
+                // This works reliably with API v3 and doesn't depend on deprecated endpoints
+                Iterable<com.atlassian.jira.rest.client.api.domain.BasicProject> projects =
+                        restClient.getProjectClient().getAllProjects().claim();
+                int projectCount = 0;
+                for (com.atlassian.jira.rest.client.api.domain.BasicProject project : projects) {
+                    projectCount++;
+                    if (projectCount == 1) {
+                        serverName = "Jira (example project: " + project.getKey() + ")";
+                    }
+                }
+                if (projectCount == 0) {
+                    serverName = "Jira (no accessible projects)";
+                }
+                JiraUtils.log("Successfully connected to Jira. Found " + projectCount + " accessible projects.");
             } catch (MalformedURLException e) {
                 return FormValidation.error("Invalid URL");
             } catch (URISyntaxException e) {

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/StringFields.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/StringFields.java
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.plugins.JiraTestResultReporter.config;
 
+import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldValue;
 import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -22,6 +23,10 @@ import hudson.RelativePath;
 import hudson.model.Descriptor;
 import hudson.tasks.test.TestResult;
 import hudson.util.ListBoxModel;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.JiraTestResultReporter.JiraTestDataPublisher.JiraTestDataPublisherDescriptor;
 import org.jenkinsci.plugins.JiraTestResultReporter.JiraUtils;
@@ -79,6 +84,35 @@ public class StringFields extends AbstractFields {
     }
 
     /**
+     * Converts plain text to Atlassian Document Format (ADF) required by Jira API v3
+     * @param text Plain text to convert
+     * @return ADF structure as ComplexIssueInputFieldValue
+     */
+    private static ComplexIssueInputFieldValue convertToADF(String text) {
+        // Create text node
+        Map<String, Object> textNode = new HashMap<>();
+        textNode.put("type", "text");
+        textNode.put("text", text);
+
+        // Create paragraph with text content
+        Map<String, Object> paragraph = new HashMap<>();
+        paragraph.put("type", "paragraph");
+        List<ComplexIssueInputFieldValue> paragraphContent = new ArrayList<>();
+        paragraphContent.add(new ComplexIssueInputFieldValue(textNode));
+        paragraph.put("content", paragraphContent);
+
+        // Create document with paragraph
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("version", 1);
+        doc.put("type", "doc");
+        List<ComplexIssueInputFieldValue> docContent = new ArrayList<>();
+        docContent.add(new ComplexIssueInputFieldValue(paragraph));
+        doc.put("content", docContent);
+
+        return new ComplexIssueInputFieldValue(doc);
+    }
+
+    /**
      * Getter for the FieldInput object
      * @param test
      * @param envVars
@@ -86,8 +120,15 @@ public class StringFields extends AbstractFields {
      */
     @Override
     public FieldInput getFieldInput(TestResult test, EnvVars envVars) {
-        FieldInput fieldInput = new FieldInput(fieldKey, VariableExpander.expandVariables(test, envVars, value));
-        return fieldInput;
+        String expandedValue = VariableExpander.expandVariables(test, envVars, value);
+
+        // For description field, convert to Atlassian Document Format (ADF) required by Jira API v3
+        if ("description".equals(fieldKey)) {
+            return new FieldInput(fieldKey, convertToADF(expandedValue));
+        }
+
+        // Other fields use plain string values
+        return new FieldInput(fieldKey, expandedValue);
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/AsynchronousJiraRestClientV3.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/AsynchronousJiraRestClientV3.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2015 Andrei Tuicu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.plugins.JiraTestResultReporter.restclientextensions;
+
+import com.atlassian.jira.rest.client.api.IssueRestClient;
+import com.atlassian.jira.rest.client.api.JiraRestClient;
+import com.atlassian.jira.rest.client.api.MetadataRestClient;
+import com.atlassian.jira.rest.client.api.ProjectRestClient;
+import com.atlassian.jira.rest.client.api.SearchRestClient;
+import com.atlassian.jira.rest.client.api.SessionRestClient;
+import com.atlassian.jira.rest.client.api.UserRestClient;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousCloudSearchRestClient;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousIssueRestClient;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousMetadataRestClient;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousProjectRestClient;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousSessionRestClient;
+import com.atlassian.jira.rest.client.internal.async.AsynchronousUserRestClient;
+import com.atlassian.jira.rest.client.internal.async.DisposableHttpClient;
+import jakarta.ws.rs.core.UriBuilder;
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Minimal custom AsynchronousJiraRestClient that uses Jira REST API v3 instead of the deprecated 'latest' version.
+ * This implementation only includes the REST clients actually used by the JiraTestResultReporter plugin.
+ *
+ * The standard jira-rest-client 7.0.1 hardcodes /rest/api/latest which has been removed by Jira Cloud.
+ */
+public class AsynchronousJiraRestClientV3 implements JiraRestClient {
+
+    private final IssueRestClient issueRestClient;
+    private final SearchRestClient searchRestClient;
+    private final MetadataRestClient metadataRestClient;
+    private final ProjectRestClient projectRestClient;
+    private final UserRestClient userRestClient;
+    private final SessionRestClient sessionRestClient;
+    private final DisposableHttpClient httpClient;
+
+    public AsynchronousJiraRestClientV3(URI serverUri, DisposableHttpClient httpClient) {
+        // Use API v3 instead of 'latest'
+        final URI baseUri = UriBuilder.fromUri(serverUri).path("/rest/api/3").build(new Object[0]);
+        this.httpClient = httpClient;
+
+        this.metadataRestClient = new AsynchronousMetadataRestClient(baseUri, httpClient);
+        this.sessionRestClient = new AsynchronousSessionRestClient(serverUri, httpClient);
+        this.issueRestClient =
+                new AsynchronousIssueRestClient(baseUri, httpClient, sessionRestClient, metadataRestClient);
+        this.searchRestClient = new AsynchronousCloudSearchRestClient(baseUri, httpClient);
+        this.projectRestClient = new AsynchronousProjectRestClient(baseUri, httpClient);
+        this.userRestClient = new AsynchronousUserRestClient(baseUri, httpClient);
+    }
+
+    @Override
+    public IssueRestClient getIssueClient() {
+        return issueRestClient;
+    }
+
+    @Override
+    public SearchRestClient getSearchClient() {
+        return searchRestClient;
+    }
+
+    @Override
+    public MetadataRestClient getMetadataClient() {
+        return metadataRestClient;
+    }
+
+    @Override
+    public ProjectRestClient getProjectClient() {
+        return projectRestClient;
+    }
+
+    @Override
+    public UserRestClient getUserClient() {
+        return userRestClient;
+    }
+
+    @Override
+    public SessionRestClient getSessionClient() {
+        return sessionRestClient;
+    }
+
+    // Unused clients - throw UnsupportedOperationException
+    @Override
+    public com.atlassian.jira.rest.client.api.ComponentRestClient getComponentClient() {
+        throw new UnsupportedOperationException("ComponentRestClient not implemented - not used by this plugin");
+    }
+
+    @Override
+    public com.atlassian.jira.rest.client.api.VersionRestClient getVersionRestClient() {
+        throw new UnsupportedOperationException("VersionRestClient not implemented - not used by this plugin");
+    }
+
+    @Override
+    public com.atlassian.jira.rest.client.api.ProjectRolesRestClient getProjectRolesRestClient() {
+        throw new UnsupportedOperationException("ProjectRolesRestClient not implemented - not used by this plugin");
+    }
+
+    @Override
+    public com.atlassian.jira.rest.client.api.AuditRestClient getAuditRestClient() {
+        throw new UnsupportedOperationException("AuditRestClient not implemented - not used by this plugin");
+    }
+
+    @Override
+    public com.atlassian.jira.rest.client.api.MyPermissionsRestClient getMyPermissionsRestClient() {
+        throw new UnsupportedOperationException("MyPermissionsRestClient not implemented - not used by this plugin");
+    }
+
+    @Override
+    public com.atlassian.jira.rest.client.api.GroupRestClient getGroupClient() {
+        throw new UnsupportedOperationException("GroupRestClient not implemented - not used by this plugin");
+    }
+
+    @Override
+    public com.atlassian.jira.rest.client.api.EmailRestClient getEmailRestClient() {
+        throw new UnsupportedOperationException("EmailRestClient not implemented - not used by this plugin");
+    }
+
+    @Override
+    public void close() throws IOException {
+        // HttpClient cleanup is handled externally
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/JiraRestClientExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/JiraRestClientExtension.java
@@ -19,8 +19,8 @@ import com.atlassian.httpclient.api.HttpClient;
 import com.atlassian.jira.rest.client.internal.async.AbstractAsynchronousRestClient;
 import com.atlassian.jira.rest.client.internal.json.GenericJsonArrayParser;
 import io.atlassian.util.concurrent.Promise;
+import jakarta.ws.rs.core.UriBuilder;
 import java.net.URI;
-import javax.ws.rs.core.UriBuilder;
 
 /**
  * Created by tuicu.
@@ -32,7 +32,7 @@ public class JiraRestClientExtension extends AbstractAsynchronousRestClient {
 
     public JiraRestClientExtension(URI serverUri, HttpClient client) {
         super(client);
-        this.baseUri = UriBuilder.fromUri(serverUri).path("/rest/api/latest").build(new Object[0]);
+        this.baseUri = UriBuilder.fromUri(serverUri).path("/rest/api/3").build(new Object[0]);
     }
 
     public Promise<Iterable<FullStatus>> getStatuses() {

--- a/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/global.jelly
@@ -5,10 +5,10 @@
     <f:section title="JiraTestResultReporter">
 
         <f:entry title="Jira API URL">
-            <f:textbox field="jiraApiUrl"/>
+            <f:textbox field="jiraUrl"/>
         </f:entry>
 
-        <f:entry title="Jira Browsable URL">
+        <f:entry title="Jira Browsable URL (Optional. If empty will use Jira API URL)">
             <f:textbox field="jiraBrowsableUrl"/>
         </f:entry>
 
@@ -25,7 +25,7 @@
         </f:entry>
 
         <f:validateButton title="Validate settings"
-                          method="validateGlobal" with="jiraApiUrl,username,password,useBearerAuth" />
+                          method="validateGlobal" with="jiraUrl,username,password,useBearerAuth" />
         <f:advanced>
             <f:entry title="Default Summary" field="summary">
                 <f:textbox field="summary" default="${descriptor.defaultSummary}"/>

--- a/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/global.jelly
@@ -4,8 +4,12 @@
 
     <f:section title="JiraTestResultReporter">
 
-        <f:entry title="Jira URL">
-            <f:textbox field="jiraUrl"/>
+        <f:entry title="Jira API URL">
+            <f:textbox field="jiraApiUrl"/>
+        </f:entry>
+
+        <f:entry title="Jira Browsable URL">
+            <f:textbox field="jiraBrowsableUrl"/>
         </f:entry>
 
         <f:entry title="Username">
@@ -21,7 +25,7 @@
         </f:entry>
 
         <f:validateButton title="Validate settings"
-                          method="validateGlobal" with="jiraUrl,username,password,useBearerAuth" />
+                          method="validateGlobal" with="jiraApiUrl,username,password,useBearerAuth" />
         <f:advanced>
             <f:entry title="Default Summary" field="summary">
                 <f:textbox field="summary" default="${descriptor.defaultSummary}"/>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
### Highlights
- Provides support for different endpoints for scoped API and browse the Jira issues
   - https://developer.atlassian.com/cloud/jira/software/jira-software-rest-api-scopes/
   - https://developer.atlassian.com/cloud/jira/software/scopes-for-connect-apps/
- Upgraded to latest version of the jira-rest-client, still pointing to old API endpoints (not v3)
- Added an adhoc client to point to v3 REST API

### Testing done
- Before this PR if we execute a pipeline like
```
pipeline {
    agent any

    stages {
        stage("Clone") {
            steps {
                // Get some code from a GitHub repository
                git 'https://github.com/imonteroperez/simple-maven-project-with-tests.git'
            }
        }
        stage("Run Tests") {
            steps {
                // Run Maven on a Unix agent.
               sh "mvn -Dmaven.test.failure.ignore=true clean package"
            }

            post {
               // If Maven was able to run the tests, even if some of the test
               // failed, record the test results and archive the jar file.
               success {
                    junit (
                       testResults: '**/target/surefire-reports/TEST-*.xml',
                       testDataPublishers: [
                       jiraTestResultReporter(
                            configs: [
                               jiraStringField(fieldKey: 'summary', value: '${DEFAULT_SUMMARY}'),
                               jiraStringField(fieldKey: 'description', value: '${DEFAULT_DESCRIPTION}'),
                               jiraStringArrayField(fieldKey: 'labels', values: [jiraArrayEntry(value: 'Jenkins'), jiraArrayEntry(value:'Integration')])
                            ],
                            projectKey: 'BEE',
                            issueType: '11185', // task
                            autoRaiseIssue: true,
                            autoResolveIssue: false,
                            autoUnlinkIssue: false,
                   )
                 ]
               )
               archiveArtifacts 'target/*.jar'
             }
           }
        }
    }
}
```
```
RestClientException{statusCode=Optional.of(410), errorCollections=[ErrorCollection{status=410, errors={}, errorMessages=[The requested API has been removed. Please migrate to the /rest/api/3/search/jql API. A full migration guideline is available at https://developer.atlassian.com/changelog/#CHANGE-2046]}]}
	at PluginClassLoader for JiraTestResultReporter//com.atlassian.jira.rest.client.internal.async.DelegatingPromise.claim(DelegatingPromise.java:45)
	at PluginClassLoader for JiraTestResultReporter//org.jenkinsci.plugins.JiraTestResultReporter.JiraUtils.getSearchResult(JiraUtils.java:346)
	at PluginClassLoader for JiraTestResultReporter//org.jenkinsci.plugins.JiraTestResultReporter.JiraUtils.findIssues(JiraUtils.java:325)
	at PluginClassLoader for JiraTestResultReporter//org.jenkinsci.plugins.JiraTestResultReporter.JiraUtils.createIssue(JiraUtils.java:168)
	at PluginClassLoader for JiraTestResultReporter//org.jenkinsci.plugins.JiraTestResultReporter.JiraTestDataPublisher.raiseIssues(JiraTestDataPublisher.java:423)
	at PluginClassLoader for JiraTestResultReporter//org.jenkinsci.plugins.JiraTestResultReporter.JiraTestDataPublisher.contributeTestData(JiraTestDataPublisher.java:306)
	at PluginClassLoader for junit//hudson.tasks.junit.JUnitResultArchiver.parseAndSummarize(JUnitResultArchiver.java:325)
```

- Also the support of double URL (API and browsable) was not provided
- Tested locally and working as expected

<img width="796" height="585" alt="Captura desde 2026-05-29 13-07-27" src="https://github.com/user-attachments/assets/138b4a01-345f-45de-b9af-49d9f78854a0" />

<img width="976" height="1094" alt="Captura desde 2026-05-29 13-06-46" src="https://github.com/user-attachments/assets/3fd70f66-b1c8-4ac3-914a-61ea225fcb2f" />

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
