### PR TITLE
Use Atlassian Document Format

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
@@ -222,6 +222,8 @@ public class AdfFieldConverter {
             connection = (HttpURLConnection) new URI(url).toURL().openConnection();
             connection.setRequestMethod("GET");
             connection.setRequestProperty("Accept", "application/json");
+            connection.setConnectTimeout(10000);
+            connection.setReadTimeout(10000);
 
             // Add authentication
             String username = descriptor.getUsername();

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2015 Andrei Tuicu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jenkinsci.plugins.JiraTestResultReporter;
+
+import com.atlassian.jira.rest.client.api.domain.CimFieldInfo;
+import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldValue;
+import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
+import hudson.model.Job;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Converts field values to Atlassian Document Format (ADF) when required by Jira API v3.
+ * Rich text fields need ADF format, which this class handles automatically based on field metadata.
+ */
+public class AdfFieldConverter {
+
+    /**
+     * Converts a FieldInput to use ADF format if the field requires it.
+     * Checks field metadata to determine if ADF conversion is needed.
+     *
+     * @param fieldInput The original field input
+     * @param project The Jenkins project (used to lookup field metadata)
+     * @return FieldInput with ADF conversion applied if needed, otherwise unchanged
+     */
+    public static FieldInput convertIfNeeded(FieldInput fieldInput, Job<?, ?> project) {
+        String fieldKey = fieldInput.getId();
+        Object value = fieldInput.getValue();
+
+        // Only convert string values
+        if (!(value instanceof String)) {
+            return fieldInput;
+        }
+
+        String textValue = (String) value;
+
+        // Check if this field needs ADF by looking at field metadata
+        if (requiresADF(fieldKey, project)) {
+            return new FieldInput(fieldKey, convertToADF(textValue));
+        }
+
+        return fieldInput;
+    }
+
+    /**
+     * Checks if a field requires ADF format based on its schema in Jira.
+     *
+     * @param fieldKey The field key
+     * @param project The Jenkins project
+     * @return true if the field requires ADF, false otherwise
+     */
+    private static boolean requiresADF(String fieldKey, Job<?, ?> project) {
+        try {
+            JiraTestDataPublisher.JiraTestDataPublisherDescriptor descriptor = JiraUtils.getJiraDescriptor();
+            String projectKey = JobConfigMapping.getInstance().getProjectKey(project);
+            Long issueType = JobConfigMapping.getInstance().getIssueType(project);
+
+            MetadataCache.CacheEntry cacheEntry = descriptor.getCacheEntry(projectKey, issueType.toString());
+            if (cacheEntry == null) {
+                return false;
+            }
+
+            Map<String, CimFieldInfo> fieldInfoMap = cacheEntry.getFieldInfoMap();
+            if (fieldInfoMap == null) {
+                return false;
+            }
+
+            CimFieldInfo fieldInfo = fieldInfoMap.get(fieldKey);
+            if (fieldInfo == null || fieldInfo.getSchema() == null) {
+                return false;
+            }
+
+            // Fields with schema type "doc" are ADF/rich-text fields in API v3
+            String schemaType = fieldInfo.getSchema().getType();
+            return "doc".equals(schemaType);
+
+        } catch (Exception e) {
+            // If we can't determine, assume no ADF needed (safer for compatibility)
+            JiraUtils.log("Unable to determine if field '" + fieldKey + "' requires ADF: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Converts plain text to Atlassian Document Format (ADF).
+     *
+     * @param text Plain text to convert
+     * @return ADF structure as ComplexIssueInputFieldValue
+     */
+    private static ComplexIssueInputFieldValue convertToADF(String text) {
+        // Create text node
+        Map<String, Object> textNode = new HashMap<>();
+        textNode.put("type", "text");
+        textNode.put("text", text);
+
+        // Create paragraph with text content
+        Map<String, Object> paragraph = new HashMap<>();
+        paragraph.put("type", "paragraph");
+        List<ComplexIssueInputFieldValue> paragraphContent = new ArrayList<>();
+        paragraphContent.add(new ComplexIssueInputFieldValue(textNode));
+        paragraph.put("content", paragraphContent);
+
+        // Create document with paragraph
+        Map<String, Object> doc = new HashMap<>();
+        doc.put("version", 1);
+        doc.put("type", "doc");
+        List<ComplexIssueInputFieldValue> docContent = new ArrayList<>();
+        docContent.add(new ComplexIssueInputFieldValue(paragraph));
+        doc.put("content", docContent);
+
+        return new ComplexIssueInputFieldValue(doc);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
@@ -15,7 +15,6 @@
  */
 package org.jenkinsci.plugins.JiraTestResultReporter;
 
-import com.atlassian.jira.rest.client.api.domain.CimFieldInfo;
 import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldValue;
 import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
 import hudson.model.Job;
@@ -25,75 +24,30 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Converts field values to Atlassian Document Format (ADF) when required by Jira API v3.
- * Rich text fields need ADF format, which this class handles automatically based on field metadata.
+ * Converts string field values to Atlassian Document Format (ADF) for Jira API v3.
+ * API v3 requires string fields to use ADF format for proper rendering.
  */
 public class AdfFieldConverter {
 
     /**
-     * Converts a FieldInput to use ADF format if the field requires it.
-     * Checks field metadata to determine if ADF conversion is needed.
+     * Converts a FieldInput to use ADF format if it's a string value.
+     * All string fields are converted to ADF format for Jira API v3 compatibility.
      *
      * @param fieldInput The original field input
-     * @param project The Jenkins project (used to lookup field metadata)
-     * @return FieldInput with ADF conversion applied if needed, otherwise unchanged
+     * @param project The Jenkins project (unused, kept for compatibility)
+     * @return FieldInput with ADF conversion applied if value is a string, otherwise unchanged
      */
     public static FieldInput convertIfNeeded(FieldInput fieldInput, Job<?, ?> project) {
         String fieldKey = fieldInput.getId();
         Object value = fieldInput.getValue();
 
-        // Only convert string values
-        if (!(value instanceof String)) {
-            return fieldInput;
-        }
-
-        String textValue = (String) value;
-
-        // Check if this field needs ADF by looking at field metadata
-        if (requiresADF(fieldKey, project)) {
+        // Only convert string values to ADF
+        if (value instanceof String) {
+            String textValue = (String) value;
             return new FieldInput(fieldKey, convertToADF(textValue));
         }
 
         return fieldInput;
-    }
-
-    /**
-     * Checks if a field requires ADF format based on its schema in Jira.
-     *
-     * @param fieldKey The field key
-     * @param project The Jenkins project
-     * @return true if the field requires ADF, false otherwise
-     */
-    private static boolean requiresADF(String fieldKey, Job<?, ?> project) {
-        try {
-            JiraTestDataPublisher.JiraTestDataPublisherDescriptor descriptor = JiraUtils.getJiraDescriptor();
-            String projectKey = JobConfigMapping.getInstance().getProjectKey(project);
-            Long issueType = JobConfigMapping.getInstance().getIssueType(project);
-
-            MetadataCache.CacheEntry cacheEntry = descriptor.getCacheEntry(projectKey, issueType.toString());
-            if (cacheEntry == null) {
-                return false;
-            }
-
-            Map<String, CimFieldInfo> fieldInfoMap = cacheEntry.getFieldInfoMap();
-            if (fieldInfoMap == null) {
-                return false;
-            }
-
-            CimFieldInfo fieldInfo = fieldInfoMap.get(fieldKey);
-            if (fieldInfo == null || fieldInfo.getSchema() == null) {
-                return false;
-            }
-
-            // Fields with schema type "doc" are ADF/rich-text fields in API v3
-            String schemaType = fieldInfo.getSchema().getType();
-            return "doc".equals(schemaType);
-
-        } catch (Exception e) {
-            // If we can't determine, assume no ADF needed (safer for compatibility)
-            JiraUtils.log("Unable to determine if field '" + fieldKey + "' requires ADF: " + e.getMessage());
-            return false;
-        }
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
@@ -15,39 +15,327 @@
  */
 package org.jenkinsci.plugins.JiraTestResultReporter;
 
+import com.atlassian.jira.rest.client.api.domain.CimFieldInfo;
 import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldValue;
 import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
 import hudson.model.Job;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONObject;
 
 /**
- * Converts string field values to Atlassian Document Format (ADF) for Jira API v3.
- * API v3 requires string fields to use ADF format for proper rendering.
+ * Converts string field values to Atlassian Document Format (ADF) for Jira Cloud REST API v3.
+ *
+ * <h3>ADF Requirement Rules</h3>
+ * <p>
+ * In Jira Cloud REST API v3, only rich-text/multi-line fields require ADF format:
+ * </p>
+ * <ul>
+ *   <li><b>Standard fields:</b> description, environment, comment (body array), worklog (comment field)</li>
+ *   <li><b>Custom fields:</b> Those with schema.custom ending in ":textarea" (multi-line text)</li>
+ * </ul>
+ *
+ * <h3>Fields That Never Use ADF</h3>
+ * <ul>
+ *   <li>summary - plain text only (the ticket title)</li>
+ *   <li>labels - array of strings</li>
+ *   <li>components - structured objects</li>
+ *   <li>Dropdowns/Select Lists - e.g., priority, status</li>
+ *   <li>Custom fields with ":textfield" - single-line plain text</li>
+ * </ul>
+ *
+ * <h3>Verification Method</h3>
+ * <p>
+ * To verify if a field requires ADF, examine its response from an existing ticket using API v3:
+ * <code>GET /rest/api/3/issue/{issueIdOrKey}</code>
+ * </p>
+ * <p>
+ * Any field returning a nested JSON with <code>"type": "doc"</code> and <code>"version": 1</code>
+ * is an ADF field.
+ * </p>
  */
 public class AdfFieldConverter {
 
+    // Cache of rich-text fields per project+issueType to avoid repeated API calls
+    private static final Map<String, Set<String>> richTextFieldCache = new ConcurrentHashMap<>();
+
     /**
-     * Converts a FieldInput to use ADF format if it's a string value.
-     * All string fields are converted to ADF format for Jira API v3 compatibility.
+     * Converts a FieldInput to use ADF format if it's a rich-text field.
+     * Queries Jira metadata to determine which fields need ADF conversion.
      *
      * @param fieldInput The original field input
-     * @param project The Jenkins project (unused, kept for compatibility)
-     * @return FieldInput with ADF conversion applied if value is a string, otherwise unchanged
+     * @param project The Jenkins project (for metadata lookup)
+     * @return FieldInput with ADF conversion applied if field needs it, otherwise unchanged
      */
     public static FieldInput convertIfNeeded(FieldInput fieldInput, Job<?, ?> project) {
         String fieldKey = fieldInput.getId();
         Object value = fieldInput.getValue();
 
-        // Only convert string values to ADF
-        if (value instanceof String) {
+        // Only convert string values
+        if (!(value instanceof String)) {
+            return fieldInput;
+        }
+
+        // Check if this field requires ADF by querying metadata
+        if (requiresADF(fieldKey, project)) {
             String textValue = (String) value;
             return new FieldInput(fieldKey, convertToADF(textValue));
         }
 
         return fieldInput;
+    }
+
+    /**
+     * Checks if a field requires ADF format by querying Jira metadata.
+     * First tries via jira-rest-client, falls back to direct HTTP call if that fails.
+     *
+     * @param fieldKey The field key
+     * @param project The Jenkins project
+     * @return true if the field requires ADF, false otherwise
+     */
+    private static boolean requiresADF(String fieldKey, Job<?, ?> project) {
+        String projectKey = JobConfigMapping.getInstance().getProjectKey(project);
+        Long issueType = JobConfigMapping.getInstance().getIssueType(project);
+        String cacheKey = projectKey + ":" + issueType;
+
+        // Check cache first
+        Set<String> richTextFields = richTextFieldCache.get(cacheKey);
+        if (richTextFields != null) {
+            return richTextFields.contains(fieldKey);
+        }
+
+        // Try to get metadata via jira-rest-client
+        boolean metadataFailed = false;
+        try {
+            JiraTestDataPublisher.JiraTestDataPublisherDescriptor descriptor = JiraUtils.getJiraDescriptor();
+            MetadataCache.CacheEntry cacheEntry = descriptor.getCacheEntry(projectKey, issueType.toString());
+
+            if (cacheEntry != null) {
+                Map<String, CimFieldInfo> fieldInfoMap = cacheEntry.getFieldInfoMap();
+                if (fieldInfoMap != null) {
+                    richTextFields = extractRichTextFields(fieldInfoMap);
+                    richTextFieldCache.put(cacheKey, richTextFields);
+                    return richTextFields.contains(fieldKey);
+                }
+            }
+            // If we got here, cacheEntry or fieldInfoMap was null - metadata unavailable
+            metadataFailed = true;
+        } catch (IllegalArgumentException e) {
+            // Known issue: jira-rest-client 7.0.1 doesn't support COPY operation from API v3
+            JiraUtils.logWarning(
+                    "Metadata parsing failed due to unsupported operation, falling back to direct API call");
+            metadataFailed = true;
+        } catch (Exception e) {
+            JiraUtils.logWarning("Unable to check field metadata, falling back to direct API call: " + e.getMessage());
+            metadataFailed = true;
+        }
+
+        // Fall back to direct HTTP call if metadata was unavailable
+        if (metadataFailed) {
+            JiraUtils.log("Metadata parsing failed, attempting direct /rest/api/3/field call");
+            richTextFields = getStringFieldsViaDirectCall(projectKey, issueType.toString());
+            if (richTextFields != null && !richTextFields.isEmpty()) {
+                JiraUtils.log("Direct API call found " + richTextFields.size()
+                        + " ADF-required fields: " + richTextFields);
+                richTextFieldCache.put(cacheKey, richTextFields);
+                return richTextFields.contains(fieldKey);
+            } else {
+                JiraUtils.logWarning("Direct API call failed or returned no ADF fields");
+            }
+        }
+
+        // If all else fails, return false (don't convert)
+        JiraUtils.logWarning("Could not determine if field '" + fieldKey
+                + "' requires ADF - not converting (this may cause 400 errors)");
+        return false;
+    }
+
+    /**
+     * Extracts rich-text field keys from CimFieldInfo map (metadata from jira-rest-client).
+     * Identifies fields that require ADF format based on their schema type.
+     *
+     * @param fieldInfoMap Map of field ID to CimFieldInfo
+     * @return Set of field IDs that require ADF format
+     */
+    private static Set<String> extractRichTextFields(Map<String, CimFieldInfo> fieldInfoMap) {
+        Set<String> richTextFields = new HashSet<>();
+        for (Map.Entry<String, CimFieldInfo> entry : fieldInfoMap.entrySet()) {
+            String fieldId = entry.getKey();
+            CimFieldInfo fieldInfo = entry.getValue();
+
+            // Standard fields that always require ADF in API v3
+            if ("description".equals(fieldId)
+                    || "environment".equals(fieldId)
+                    || "comment".equals(fieldId)
+                    || "worklog".equals(fieldId)) {
+                richTextFields.add(fieldId);
+                continue;
+            }
+
+            // Fields with schema type "doc" are ADF fields
+            if (fieldInfo.getSchema() != null && "doc".equals(fieldInfo.getSchema().getType())) {
+                richTextFields.add(fieldId);
+            }
+        }
+        return richTextFields;
+    }
+
+    /**
+     * Gets all ADF-required fields by making a direct HTTP call to Jira API /rest/api/3/field.
+     *
+     * <p>In Jira Cloud REST API v3, rich-text fields require ADF format:</p>
+     * <ul>
+     *   <li>Standard fields: description, environment, comment, worklog</li>
+     *   <li>Custom fields with schema.custom ending in ":textarea" (multi-line text)</li>
+     * </ul>
+     *
+     * <p>Fields that do NOT require ADF:</p>
+     * <ul>
+     *   <li>summary (plain text title)</li>
+     *   <li>Custom fields with ":textfield" (single-line text)</li>
+     *   <li>labels, components, dropdowns, etc.</li>
+     * </ul>
+     *
+     * @param projectKey The Jira project key (unused, kept for potential future filtering)
+     * @param issueType The issue type ID (unused, kept for potential future filtering)
+     * @return Set of field IDs that require ADF format, or null if the API call fails
+     */
+    private static Set<String> getStringFieldsViaDirectCall(String projectKey, String issueType) {
+        HttpURLConnection connection = null;
+        try {
+            JiraTestDataPublisher.JiraTestDataPublisherDescriptor descriptor = JiraUtils.getJiraDescriptor();
+            String jiraUrl = descriptor.getJiraUrl();
+            if (jiraUrl.endsWith("/")) {
+                jiraUrl = jiraUrl.substring(0, jiraUrl.length() - 1);
+            }
+
+            // Use /rest/api/3/field to get all field definitions
+            String url = jiraUrl + "/rest/api/3/field";
+
+            connection = (HttpURLConnection) new URI(url).toURL().openConnection();
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Accept", "application/json");
+
+            // Add authentication
+            String username = descriptor.getUsername();
+            String password = descriptor.getPassword().getPlainText();
+            String auth = username + ":" + password;
+            String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+            connection.setRequestProperty("Authorization", "Basic " + encodedAuth);
+
+            int responseCode = connection.getResponseCode();
+            if (responseCode == 200) {
+                BufferedReader reader =
+                        new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
+                StringBuilder response = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    response.append(line);
+                }
+                reader.close();
+
+                Set<String> fields = parseAdfFieldsFromJson(response.toString());
+                JiraUtils.log("Successfully parsed " + (fields != null ? fields.size() : 0)
+                        + " ADF-required fields from /rest/api/3/field");
+                return fields;
+            } else {
+                // Read error response body for debugging
+                String errorBody = "";
+                try {
+                    BufferedReader errorReader = new BufferedReader(
+                            new InputStreamReader(connection.getErrorStream(), StandardCharsets.UTF_8));
+                    StringBuilder errorResponse = new StringBuilder();
+                    String line;
+                    while ((line = errorReader.readLine()) != null) {
+                        errorResponse.append(line);
+                    }
+                    errorReader.close();
+                    errorBody = errorResponse.toString();
+                } catch (Exception ignored) {
+                }
+                JiraUtils.logWarning("Failed to get field metadata via direct API call, status: " + responseCode
+                        + ", body: " + errorBody);
+            }
+        } catch (Exception e) {
+            JiraUtils.logWarning("Error making direct API call for field metadata: " + e.getMessage());
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parses JSON response from /rest/api/3/field to extract ADF-required fields.
+     *
+     * In Jira Cloud REST API v3, ADF is required for rich-text/multi-line fields:
+     * - Standard fields: description, environment, comment (body array), worklog (comment field)
+     * - Custom fields where schema.custom ends with ":textarea" (multi-line text fields)
+     *
+     * Fields that never use ADF:
+     * - summary (plain text only)
+     * - Custom fields with ":textfield" (single-line text)
+     * - labels, components, priority, status, and other dropdowns/select lists
+     */
+    private static Set<String> parseAdfFieldsFromJson(String jsonResponse) {
+        Set<String> adfFields = new HashSet<>();
+        try {
+            JiraUtils.log("Parsing /rest/api/3/field response to identify ADF-required fields");
+            JSONArray fields = new JSONArray(jsonResponse);
+
+            for (int i = 0; i < fields.length(); i++) {
+                JSONObject field = fields.getJSONObject(i);
+                String fieldId = field.getString("id");
+
+                if (!field.has("schema")) {
+                    continue;
+                }
+
+                JSONObject schema = field.getJSONObject("schema");
+
+                // Standard rich-text fields that always require ADF in API v3
+                // These support rich formatting (bold, bullets, etc.)
+                if ("description".equals(fieldId)
+                        || "environment".equals(fieldId)
+                        || "comment".equals(fieldId)
+                        || "worklog".equals(fieldId)) {
+                    JiraUtils.log("Found standard ADF field: " + fieldId);
+                    adfFields.add(fieldId);
+                    continue;
+                }
+
+                // Custom fields: check if it's a textarea (multi-line text = ADF)
+                // Single-line textfields use plain strings, multi-line textareas use ADF
+                if (schema.has("custom")) {
+                    String customType = schema.getString("custom");
+                    if (customType.endsWith(":textarea")) {
+                        JiraUtils.log("Found custom textarea field requiring ADF: " + fieldId + " (" + customType + ")");
+                        adfFields.add(fieldId);
+                    } else if (customType.endsWith(":textfield")) {
+                        JiraUtils.log("Skipping textfield (single-line, no ADF): " + fieldId);
+                    }
+                }
+            }
+
+            JiraUtils.log("Total ADF-required fields found: " + adfFields.size());
+        } catch (Exception e) {
+            JiraUtils.logWarning("Error parsing field metadata JSON: " + e.getMessage());
+            e.printStackTrace();
+        }
+        return adfFields;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
@@ -38,7 +38,7 @@ import org.codehaus.jettison.json.JSONObject;
 /**
  * Converts string field values to Atlassian Document Format (ADF) for Jira Cloud REST API v3.
  *
- * <h3>ADF Requirement Rules</h3>
+ * <h2>ADF Requirement Rules</h2>
  * <p>
  * In Jira Cloud REST API v3, only rich-text/multi-line fields require ADF format:
  * </p>
@@ -47,7 +47,7 @@ import org.codehaus.jettison.json.JSONObject;
  *   <li><b>Custom fields:</b> Those with schema.custom ending in ":textarea" (multi-line text)</li>
  * </ul>
  *
- * <h3>Fields That Never Use ADF</h3>
+ * <h2>Fields That Never Use ADF</h2>
  * <ul>
  *   <li>summary - plain text only (the ticket title)</li>
  *   <li>labels - array of strings</li>
@@ -56,7 +56,7 @@ import org.codehaus.jettison.json.JSONObject;
  *   <li>Custom fields with ":textfield" - single-line plain text</li>
  * </ul>
  *
- * <h3>Verification Method</h3>
+ * <h2>Verification Method</h2>
  * <p>
  * To verify if a field requires ADF, examine its response from an existing ticket using API v3:
  * <code>GET /rest/api/3/issue/{issueIdOrKey}</code>

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/AdfFieldConverter.java
@@ -134,25 +134,19 @@ public class AdfFieldConverter {
             metadataFailed = true;
         } catch (IllegalArgumentException e) {
             // Known issue: jira-rest-client 7.0.1 doesn't support COPY operation from API v3
-            JiraUtils.logWarning(
-                    "Metadata parsing failed due to unsupported operation, falling back to direct API call");
+            // Silently fall back to direct API call
             metadataFailed = true;
         } catch (Exception e) {
-            JiraUtils.logWarning("Unable to check field metadata, falling back to direct API call: " + e.getMessage());
+            // Silently fall back to direct API call
             metadataFailed = true;
         }
 
         // Fall back to direct HTTP call if metadata was unavailable
         if (metadataFailed) {
-            JiraUtils.log("Metadata parsing failed, attempting direct /rest/api/3/field call");
             richTextFields = getStringFieldsViaDirectCall(projectKey, issueType.toString());
             if (richTextFields != null && !richTextFields.isEmpty()) {
-                JiraUtils.log("Direct API call found " + richTextFields.size()
-                        + " ADF-required fields: " + richTextFields);
                 richTextFieldCache.put(cacheKey, richTextFields);
                 return richTextFields.contains(fieldKey);
-            } else {
-                JiraUtils.logWarning("Direct API call failed or returned no ADF fields");
             }
         }
 
@@ -185,7 +179,8 @@ public class AdfFieldConverter {
             }
 
             // Fields with schema type "doc" are ADF fields
-            if (fieldInfo.getSchema() != null && "doc".equals(fieldInfo.getSchema().getType())) {
+            if (fieldInfo.getSchema() != null
+                    && "doc".equals(fieldInfo.getSchema().getType())) {
                 richTextFields.add(fieldId);
             }
         }
@@ -246,10 +241,7 @@ public class AdfFieldConverter {
                 }
                 reader.close();
 
-                Set<String> fields = parseAdfFieldsFromJson(response.toString());
-                JiraUtils.log("Successfully parsed " + (fields != null ? fields.size() : 0)
-                        + " ADF-required fields from /rest/api/3/field");
-                return fields;
+                return parseAdfFieldsFromJson(response.toString());
             } else {
                 // Read error response body for debugging
                 String errorBody = "";
@@ -293,7 +285,6 @@ public class AdfFieldConverter {
     private static Set<String> parseAdfFieldsFromJson(String jsonResponse) {
         Set<String> adfFields = new HashSet<>();
         try {
-            JiraUtils.log("Parsing /rest/api/3/field response to identify ADF-required fields");
             JSONArray fields = new JSONArray(jsonResponse);
 
             for (int i = 0; i < fields.length(); i++) {
@@ -312,7 +303,6 @@ public class AdfFieldConverter {
                         || "environment".equals(fieldId)
                         || "comment".equals(fieldId)
                         || "worklog".equals(fieldId)) {
-                    JiraUtils.log("Found standard ADF field: " + fieldId);
                     adfFields.add(fieldId);
                     continue;
                 }
@@ -322,18 +312,12 @@ public class AdfFieldConverter {
                 if (schema.has("custom")) {
                     String customType = schema.getString("custom");
                     if (customType.endsWith(":textarea")) {
-                        JiraUtils.log("Found custom textarea field requiring ADF: " + fieldId + " (" + customType + ")");
                         adfFields.add(fieldId);
-                    } else if (customType.endsWith(":textfield")) {
-                        JiraUtils.log("Skipping textfield (single-line, no ADF): " + fieldId);
                     }
                 }
             }
-
-            JiraUtils.log("Total ADF-required fields found: " + adfFields.size());
         } catch (Exception e) {
             JiraUtils.logWarning("Error parsing field metadata JSON: " + e.getMessage());
-            e.printStackTrace();
         }
         return adfFields;
     }

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -48,7 +48,6 @@ import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.JiraTestResultReporter.config.AbstractFields;
-import org.jenkinsci.plugins.JiraTestResultReporter.AdfFieldConverter;
 
 /**
  * Created by tuicu.

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraUtils.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.JiraTestResultReporter.config.AbstractFields;
+import org.jenkinsci.plugins.JiraTestResultReporter.AdfFieldConverter;
 
 /**
  * Created by tuicu.
@@ -184,7 +185,7 @@ public class JiraUtils {
                     return null;
                 }
             }
-            String issueKey = JiraUtils.createIssueInput(issueInput, test, attachments);
+            String issueKey = JiraUtils.createIssueInput(issueInput, project, test, attachments);
             TestToIssueMapping.getInstance().addTestToIssueMapping(job, test.getId(), issueKey);
             return issueKey;
         }
@@ -229,6 +230,7 @@ public class JiraUtils {
                 JobConfigMapping.getInstance().getIssueType(project));
         // first use the templates and then override them if other configs exist and it is requested from a job
         // execution (not UI badge)
+        // Note: We do NOT convert to ADF here because this IssueInput is also used for JQL search
         for (AbstractFields f : JiraTestDataPublisher.JiraTestDataPublisherDescriptor.templates) {
             newIssueBuilder.setFieldInput(f.getFieldInput(test, envVars));
         }
@@ -241,10 +243,39 @@ public class JiraUtils {
         return newIssueBuilder.build();
     }
 
-    private static String createIssueInput(IssueInput issueInput, CaseResult test, List<String> attachments) {
+    /**
+     * Converts an IssueInput's fields to ADF format where required.
+     * Creates a new IssueInput with ADF-converted values for rich text fields.
+     *
+     * @param issueInput The original IssueInput with plain text values
+     * @param project The Jenkins project (for field metadata lookup)
+     * @return A new IssueInput with ADF conversion applied to fields that need it
+     */
+    private static IssueInput convertIssueInputFieldsToADF(IssueInput issueInput, Job<?, ?> project) {
+        String projectKey = JobConfigMapping.getInstance().getProjectKey(project);
+        Long issueType = JobConfigMapping.getInstance().getIssueType(project);
+        IssueInputBuilder builder = new IssueInputBuilder(projectKey, issueType);
+
+        // Iterate through all fields and convert to ADF if needed
+        Map<String, FieldInput> fields = issueInput.getFields();
+        for (Map.Entry<String, FieldInput> entry : fields.entrySet()) {
+            FieldInput field = entry.getValue();
+            FieldInput convertedField = AdfFieldConverter.convertIfNeeded(field, project);
+            builder.setFieldInput(convertedField);
+        }
+
+        return builder.build();
+    }
+
+    private static String createIssueInput(
+            IssueInput issueInput, Job<?, ?> project, CaseResult test, List<String> attachments) {
+        // Convert fields to ADF format if needed, just before sending to Jira API
+        // This ensures JQL search (which uses the same issueInput) works with plain text
+        IssueInput convertedInput = convertIssueInputFieldsToADF(issueInput, project);
+
         final IssueRestClient issueClient =
                 JiraUtils.getJiraDescriptor().getRestClient().getIssueClient();
-        Promise<BasicIssue> issuePromise = issueClient.createIssue(issueInput);
+        Promise<BasicIssue> issuePromise = issueClient.createIssue(convertedInput);
         String key = issuePromise.claim().getKey();
         Issue issue = issueClient.getIssue(key).claim();
         URI attachmentsUri = issue.getAttachmentsUri();

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/MetadataCache.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/MetadataCache.java
@@ -197,6 +197,17 @@ public class MetadataCache {
                                 + " issueType:" + issueType + "JIRA Version" + serverInfo.getVersion());
                         JiraUtils.logError("ERROR: RestClientException error", e);
                         return null;
+                    } catch (IllegalArgumentException e) {
+                        // Known issue: jira-rest-client doesn't support COPY operation from Jira API v3
+                        // This is expected and handled by fallback to direct API calls in AdfFieldConverter
+                        if (e.getMessage() != null && e.getMessage().contains("StandardOperation.COPY")) {
+                            JiraUtils.log(
+                                    "Metadata parsing failed (unsupported COPY operation), using fallback method");
+                            return null;
+                        }
+                        // For other IllegalArgumentExceptions, log as error
+                        JiraUtils.logError("ERROR: Invalid argument", e);
+                        return null;
                     } catch (Exception e) {
                         JiraUtils.logError("ERROR: Unknown error", e);
                         return null;

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/StringFields.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/StringFields.java
@@ -121,14 +121,7 @@ public class StringFields extends AbstractFields {
     @Override
     public FieldInput getFieldInput(TestResult test, EnvVars envVars) {
         String expandedValue = VariableExpander.expandVariables(test, envVars, value);
-
-        // For description field, convert to Atlassian Document Format (ADF) required by Jira API v3
-        if ("description".equals(fieldKey)) {
-            return new FieldInput(fieldKey, convertToADF(expandedValue));
-        }
-
-        // Other fields use plain string values
-        return new FieldInput(fieldKey, expandedValue);
+        return new FieldInput(fieldKey, convertToADF(expandedValue));
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/StringFields.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/StringFields.java
@@ -15,7 +15,6 @@
  */
 package org.jenkinsci.plugins.JiraTestResultReporter.config;
 
-import com.atlassian.jira.rest.client.api.domain.input.ComplexIssueInputFieldValue;
 import com.atlassian.jira.rest.client.api.domain.input.FieldInput;
 import hudson.EnvVars;
 import hudson.Extension;
@@ -23,10 +22,6 @@ import hudson.RelativePath;
 import hudson.model.Descriptor;
 import hudson.tasks.test.TestResult;
 import hudson.util.ListBoxModel;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.JiraTestResultReporter.JiraTestDataPublisher.JiraTestDataPublisherDescriptor;
 import org.jenkinsci.plugins.JiraTestResultReporter.JiraUtils;
@@ -84,36 +79,10 @@ public class StringFields extends AbstractFields {
     }
 
     /**
-     * Converts plain text to Atlassian Document Format (ADF) required by Jira API v3
-     * @param text Plain text to convert
-     * @return ADF structure as ComplexIssueInputFieldValue
-     */
-    private static ComplexIssueInputFieldValue convertToADF(String text) {
-        // Create text node
-        Map<String, Object> textNode = new HashMap<>();
-        textNode.put("type", "text");
-        textNode.put("text", text);
-
-        // Create paragraph with text content
-        Map<String, Object> paragraph = new HashMap<>();
-        paragraph.put("type", "paragraph");
-        List<ComplexIssueInputFieldValue> paragraphContent = new ArrayList<>();
-        paragraphContent.add(new ComplexIssueInputFieldValue(textNode));
-        paragraph.put("content", paragraphContent);
-
-        // Create document with paragraph
-        Map<String, Object> doc = new HashMap<>();
-        doc.put("version", 1);
-        doc.put("type", "doc");
-        List<ComplexIssueInputFieldValue> docContent = new ArrayList<>();
-        docContent.add(new ComplexIssueInputFieldValue(paragraph));
-        doc.put("content", docContent);
-
-        return new ComplexIssueInputFieldValue(doc);
-    }
-
-    /**
-     * Getter for the FieldInput object
+     * Getter for the FieldInput object.
+     * Returns the field value as plain text. ADF conversion (if needed) is handled
+     * by AdfFieldConverter based on the field's schema type from Jira metadata.
+     *
      * @param test
      * @param envVars
      * @return
@@ -121,7 +90,7 @@ public class StringFields extends AbstractFields {
     @Override
     public FieldInput getFieldInput(TestResult test, EnvVars envVars) {
         String expandedValue = VariableExpander.expandVariables(test, envVars, value);
-        return new FieldInput(fieldKey, convertToADF(expandedValue));
+        return new FieldInput(fieldKey, expandedValue);
     }
 
     @Override


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
### Highlights
- On https://github.com/jenkinsci/JiraTestResultReporter-plugin/pull/285 we used the v3 REST API 
- For some string fields it should use the Atlassian Document Format 
- In the previous PR it was only limited to the description field but other customfields could be based on text
- Actually based on the Atlassian documentation about ADF:
   - In API v3, the native rich text fields that will always accept and return ADF blocks are: `description`, `environment`, `comment` (the body array within any comment block) and `worklog` (the comment field inside worklog entries)
   - Custom fields vary based on how they were configured. To find out which custom fields require ADF,  we need to inspect the `rest/api/3/field` 
   - Fields that never use ADF: `summary` (The ticket title), `labels`, `components` and Dropdowns / Select Lists (e.g., `priority`, `status`)
- See https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/

### Testing notes
- Tested locally using `junit` publisher configured to populate a customfield that requires ADF
```
junit (
   testResults: '**/target/surefire-reports/TEST-*.xml',
   testDataPublishers: [
          jiraTestResultReporter(
                configs: [
                    jiraStringField(fieldKey: 'summary', value: '${DEFAULT_SUMMARY}'),
                    jiraStringField(fieldKey: 'description', value: '${DEFAULT_DESCRIPTION}'),
                    jiraStringField(fieldKey: 'customfield_12662', value: "This is the AC"),
                    jiraStringArrayField(fieldKey: 'labels', values: [jiraArrayEntry(value: 'Jenkins'), jiraArrayEntry(value:'Integration')])
                 ],
                 projectKey: 'JIRA',
                 issueType: '11185',
                 autoRaiseIssue: true,
                 autoResolveIssue: false,
                 autoUnlinkIssue: false,
          )
    ]
)
```
- Before this PR:
```
RestClientException{statusCode=Optional.of(400), errorCollections=[ErrorCollection{status=400, errors={customfield_12662=Operation value must be an Atlassian Document (see the Atlassian Document Format)}, errorMessages=[]}]}
	at PluginClassLoader for JiraTestResultReporter//com.atlassian.jira.rest.client.internal.async.DelegatingPromise.claim(DelegatingPromise.java:45)
	at PluginClassLoader for JiraTestResultReporter//org.jenkinsci.plugins.JiraTestResultReporter.JiraUtils.createIssueInput(JiraUtils.java:248)
[...]
```
- After this PR:
```
2026-06-02 09:09:08.099+0000 [id=243]	INFO	o.j.p.J.JiraUtils#log: resolution = "unresolved" and project = "BEE" and text ~ "\"test.OtherTest.mytestOther : oops\""
2026-06-02 09:09:09.730+0000 [id=243]	INFO	o.j.p.J.JiraUtils#log: Metadata parsing failed (unsupported COPY operation), using fallback method
2026-06-02 09:09:14.597+0000 [id=243]	INFO	o.j.p.J.JiraUtils#log: resolution = "unresolved" and project = "BEE" and text ~ "\"test.SomeTest.test3o : oops\""
2026-06-02 09:09:19.508+0000 [id=243]	INFO	o.j.p.J.JiraUtils#log: resolution = "unresolved" and project = "BEE" and text ~ "\"test.SomeTest.test4o : oops\""
```
- Tickets created as expected 
<img width="524" height="598" alt="image" src="https://github.com/user-attachments/assets/77a3cd79-cdc4-4119-9f14-a177e85520f7" />


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
