### PR TITLE
Require Jenkins 2.555.1 or newer and Java 21

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,4 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
--Pjava-level-21
 -Dchangelist.format=%d.v%s

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.504</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.555</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <jira-rest-client.version>7.0.1</jira-rest-client.version>
     <fugue.version>6.1.4</fugue.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5983.v443959746f1f</version>
+        <version>6509.v993a_c958a_e35</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Require Jenkins 2.555.1 or newer (Java 21)

Fixes #291

Some of the dependent libraries require Java 21. Compilation is configured to require Java 21.  However, Jenkins 2.504.x, 2.528.x, and 2.541.x are all supported with Java 17.  If the plugin is installed on a Jenkins version that is running Java 17, the plugin will fail to load because it is built with Java 21 byte code.

Update the minimum Jenkins version to require a Jenkins version that no longer support Java 17.  That avoids the Java 17 issue and continues the forward progress of the plugin.

Removed the java-level-21 Maven profile because it is already enforced by the minimum Jenkins version.

Detected in plugin BOM release build:

* https://github.com/jenkinsci/bom/issues/6905

### Testing done

* Confirmed that tests pass with Java 21 using `mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
