### PR TITLE
global option to still support older jira versions with just v2 REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This plugin allows you to create and/or link issues from Jira to failed tests in
 ### Global Configuration
 
 Before doing anything else, the global configurations must be done.
-In order to do these go to **Manage Jenkins -> Configure System -> JiraTestResultReporter** and enter here the JIRA server url the username and password. It is highly recommended that you click the Validate Settings button every time you make any changes here.
+In order to do these go to **Manage Jenkins -> Configure System -> JiraTestResultReporter** and enter here the JIRA server url the username and password. Instead of the basic authentication on newer Jira server versions bearer authentication could be used with the corresponding checkbox. For older Jira REST API version the checkbox **Use latest Rest API instead of v3** could be activated. It is highly recommended that you click the Validate Settings button every time you make any changes here.
 Also from here you can configure the global templates for Summary and Description, by clicking on the Advanced button. These templates will be used to create issues if they are not overridden in the job configuration.
 
 ![image of global config settings](img/global-config.png)

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -754,22 +754,22 @@ public class JiraTestDataPublisher extends TestDataPublisher {
                     return FormValidation.error("Invalid URL");
                 }
                 Secret pass = Secret.fromString(password);
-                // Validate connection by trying to access projects (API v3 compatible, lightweight)
+                // Validate connection by trying to access projects (API v3/latest compatible, lightweight)
                 AsynchronousHttpClientFactory httpClientFactory = new AsynchronousHttpClientFactory();
                 JiraRestClient restClient;
                 if (useBearerAuth) {
                     BearerAuthenticationHandler handler = new BearerAuthenticationHandler(pass.getPlainText());
                     restClient = new AsynchronousJiraRestClientV3(
-                            uri, httpClientFactory.createClient(uri, handler), getLatestRestApiVersionString());
+                            uri, httpClientFactory.createClient(uri, handler), useLatestRestApi ? "latest" : "3");
                 } else {
                     BasicHttpAuthenticationHandler handler =
                             new BasicHttpAuthenticationHandler(username, pass.getPlainText());
                     restClient = new AsynchronousJiraRestClientV3(
-                            uri, httpClientFactory.createClient(uri, handler), getLatestRestApiVersionString());
+                            uri, httpClientFactory.createClient(uri, handler), useLatestRestApi ? "latest" : "3");
                 }
 
                 // Validate by getting accessible projects - proves authentication and basic permissions
-                // This works reliably with API v3 and doesn't depend on deprecated endpoints
+                // This works reliably with API v3/latest and doesn't depend on deprecated endpoints
                 Iterable<com.atlassian.jira.rest.client.api.domain.BasicProject> projects =
                         restClient.getProjectClient().getAllProjects().claim();
                 int projectCount = 0;

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -516,6 +516,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         private String username = null;
         private Secret password = null;
         private boolean useBearerAuth = false;
+        private boolean useLatestRestApi = false;
         private String defaultSummary;
         private String defaultDescription;
 
@@ -537,6 +538,14 @@ public class JiraTestDataPublisher extends TestDataPublisher {
 
         public boolean getUseBearerAuth() {
             return useBearerAuth;
+        }
+
+        public boolean getUseLatestRestApi() {
+            return useLatestRestApi;
+        }
+
+        public String getLatestRestApiVersionString() {
+            return useLatestRestApi ? "latest" : "3";
         }
 
         public String getJiraUrl() {
@@ -597,18 +606,18 @@ public class JiraTestDataPublisher extends TestDataPublisher {
                 AsynchronousHttpClientFactory httpClientFactory = new AsynchronousHttpClientFactory();
                 if (useBearerAuth) {
                     BearerAuthenticationHandler handler = new BearerAuthenticationHandler(password.getPlainText());
-                    restClient =
-                            new AsynchronousJiraRestClientV3(jiraUri, httpClientFactory.createClient(jiraUri, handler));
+                    restClient = new AsynchronousJiraRestClientV3(
+                            jiraUri, httpClientFactory.createClient(jiraUri, handler), getLatestRestApiVersionString());
 
-                    restClientExtension =
-                            new JiraRestClientExtension(jiraUri, httpClientFactory.createClient(jiraUri, handler));
+                    restClientExtension = new JiraRestClientExtension(
+                            jiraUri, httpClientFactory.createClient(jiraUri, handler), getLatestRestApiVersionString());
                 } else {
                     BasicHttpAuthenticationHandler handler =
                             new BasicHttpAuthenticationHandler(username, password.getPlainText());
-                    restClient =
-                            new AsynchronousJiraRestClientV3(jiraUri, httpClientFactory.createClient(jiraUri, handler));
-                    restClientExtension =
-                            new JiraRestClientExtension(jiraUri, httpClientFactory.createClient(jiraUri, handler));
+                    restClient = new AsynchronousJiraRestClientV3(
+                            jiraUri, httpClientFactory.createClient(jiraUri, handler), getLatestRestApiVersionString());
+                    restClientExtension = new JiraRestClientExtension(
+                            jiraUri, httpClientFactory.createClient(jiraUri, handler), getLatestRestApiVersionString());
                 }
                 tryCreatingStatusToCategoryMap();
             }
@@ -648,6 +657,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             username = json.getString("username");
             password = Secret.fromString(json.getString("password"));
             useBearerAuth = json.getBoolean("useBearerAuth");
+            useLatestRestApi = json.getBoolean("useLatestRestApi");
             defaultSummary = json.getString("summary");
             defaultDescription = json.getString("description");
 
@@ -655,6 +665,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
                     || json.getString("username").equals("")
                     || json.getString("password").equals("")) {
                 useBearerAuth = false;
+                useLatestRestApi = false;
                 restClient = null;
                 restClientExtension = null;
                 save();
@@ -664,18 +675,18 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             AsynchronousHttpClientFactory httpClientFactory = new AsynchronousHttpClientFactory();
             if (useBearerAuth) {
                 BearerAuthenticationHandler handler = new BearerAuthenticationHandler(password.getPlainText());
-                restClient =
-                        new AsynchronousJiraRestClientV3(jiraUri, httpClientFactory.createClient(jiraUri, handler));
+                restClient = new AsynchronousJiraRestClientV3(
+                        jiraUri, httpClientFactory.createClient(jiraUri, handler), getLatestRestApiVersionString());
 
-                restClientExtension =
-                        new JiraRestClientExtension(jiraUri, httpClientFactory.createClient(jiraUri, handler));
+                restClientExtension = new JiraRestClientExtension(
+                        jiraUri, httpClientFactory.createClient(jiraUri, handler), getLatestRestApiVersionString());
             } else {
                 BasicHttpAuthenticationHandler handler =
                         new BasicHttpAuthenticationHandler(username, password.getPlainText());
-                restClient =
-                        new AsynchronousJiraRestClientV3(jiraUri, httpClientFactory.createClient(jiraUri, handler));
-                restClientExtension =
-                        new JiraRestClientExtension(jiraUri, httpClientFactory.createClient(jiraUri, handler));
+                restClient = new AsynchronousJiraRestClientV3(
+                        jiraUri, httpClientFactory.createClient(jiraUri, handler), getLatestRestApiVersionString());
+                restClientExtension = new JiraRestClientExtension(
+                        jiraUri, httpClientFactory.createClient(jiraUri, handler), getLatestRestApiVersionString());
             }
             tryCreatingStatusToCategoryMap();
             save();
@@ -730,7 +741,8 @@ public class JiraTestDataPublisher extends TestDataPublisher {
                 @QueryParameter String jiraUrl,
                 @QueryParameter String username,
                 @QueryParameter String password,
-                @QueryParameter boolean useBearerAuth) {
+                @QueryParameter boolean useBearerAuth,
+                @QueryParameter boolean useLatestRestApi) {
 
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             String serverName = "Jira";
@@ -747,11 +759,13 @@ public class JiraTestDataPublisher extends TestDataPublisher {
                 JiraRestClient restClient;
                 if (useBearerAuth) {
                     BearerAuthenticationHandler handler = new BearerAuthenticationHandler(pass.getPlainText());
-                    restClient = new AsynchronousJiraRestClientV3(uri, httpClientFactory.createClient(uri, handler));
+                    restClient = new AsynchronousJiraRestClientV3(
+                            uri, httpClientFactory.createClient(uri, handler), getLatestRestApiVersionString());
                 } else {
                     BasicHttpAuthenticationHandler handler =
                             new BasicHttpAuthenticationHandler(username, pass.getPlainText());
-                    restClient = new AsynchronousJiraRestClientV3(uri, httpClientFactory.createClient(uri, handler));
+                    restClient = new AsynchronousJiraRestClientV3(
+                            uri, httpClientFactory.createClient(uri, handler), getLatestRestApiVersionString());
                 }
 
                 // Validate by getting accessible projects - proves authentication and basic permissions

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/AsynchronousJiraRestClientV3.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/AsynchronousJiraRestClientV3.java
@@ -49,9 +49,12 @@ public class AsynchronousJiraRestClientV3 implements JiraRestClient {
     private final SessionRestClient sessionRestClient;
     private final DisposableHttpClient httpClient;
 
-    public AsynchronousJiraRestClientV3(URI serverUri, DisposableHttpClient httpClient) {
-        // Use API v3 instead of 'latest'
-        final URI baseUri = UriBuilder.fromUri(serverUri).path("/rest/api/3").build(new Object[0]);
+    public AsynchronousJiraRestClientV3(
+            URI serverUri, DisposableHttpClient httpClient, String latestRestApiVersionString) {
+        // Use API v3 or 'latest' based on user setting from latestRestApiVersionString
+        final URI baseUri = UriBuilder.fromUri(serverUri)
+                .path("/rest/api/" + latestRestApiVersionString)
+                .build(new Object[0]);
         this.httpClient = httpClient;
 
         this.metadataRestClient = new AsynchronousMetadataRestClient(baseUri, httpClient);

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/JiraRestClientExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/restclientextensions/JiraRestClientExtension.java
@@ -30,9 +30,11 @@ public class JiraRestClientExtension extends AbstractAsynchronousRestClient {
 
     private URI baseUri;
 
-    public JiraRestClientExtension(URI serverUri, HttpClient client) {
+    public JiraRestClientExtension(URI serverUri, HttpClient client, String latestRestApiVersionString) {
         super(client);
-        this.baseUri = UriBuilder.fromUri(serverUri).path("/rest/api/3").build(new Object[0]);
+        this.baseUri = UriBuilder.fromUri(serverUri)
+                .path("/rest/api/" + latestRestApiVersionString)
+                .build(new Object[0]);
     }
 
     public Promise<Iterable<FullStatus>> getStatuses() {

--- a/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/global.jelly
@@ -24,8 +24,12 @@
             <f:checkbox/>
         </f:entry>
 
+        <f:entry title="Use latest Rest API instead of v3" field="useLatestRestApi" >
+            <f:checkbox/>
+        </f:entry>
+
         <f:validateButton title="Validate settings"
-                          method="validateGlobal" with="jiraUrl,username,password,useBearerAuth" />
+                          method="validateGlobal" with="jiraUrl,username,password,useBearerAuth,useLatestRestApi" />
         <f:advanced>
             <f:entry title="Default Summary" field="summary">
                 <f:textbox field="summary" default="${descriptor.defaultSummary}"/>

--- a/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/help-useLatestRestApi.html
+++ b/src/main/resources/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher/help-useLatestRestApi.html
@@ -1,0 +1,4 @@
+<div>
+    Newer Jira versions support REST API v3, see https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/ . v3 is the default.
+    Older Jira Server just support REST API v2 aka latest. This option allows requests with the older API. For current Jira Cloud versions leave this unchecked.
+</div>


### PR DESCRIPTION


<!-- Please describe your pull request here. -->

With PR #285 , just Jira servers are supported with REST API v3. Older Jira versions/On-Premises need to stick to release https://github.com/jenkinsci/JiraTestResultReporter-plugin/releases/tag/340.v8ea_26d65222d to be supported . That seems to be not necessary to my testing with Jira 10.3.x .

This change adds a global config option to still use latest for REST API calls.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
