### PR TITLE
Exception with jiraBrowsableUri

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestDataPublisher.java
@@ -544,7 +544,9 @@ public class JiraTestDataPublisher extends TestDataPublisher {
         }
 
         public String getJiraBrowsableUrl() {
-            return jiraBrowsableUri != null ? jiraBrowsableUri.toString() : null;
+            return jiraBrowsableUri != null
+                    ? (jiraBrowsableUri.toString().isEmpty() ? getJiraUrl() : jiraBrowsableUri.toString())
+                    : getJiraUrl();
         }
 
         public JiraRestClient getRestClient() {
@@ -734,6 +736,7 @@ public class JiraTestDataPublisher extends TestDataPublisher {
 
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             String serverName = "Jira";
+            JiraRestClient restClient = null;
             try {
                 // implicit URL validation check
                 URI uri = new URI(jiraUrl);
@@ -744,7 +747,6 @@ public class JiraTestDataPublisher extends TestDataPublisher {
                 Secret pass = Secret.fromString(password);
                 // Validate connection by trying to access projects (API v3 compatible, lightweight)
                 AsynchronousHttpClientFactory httpClientFactory = new AsynchronousHttpClientFactory();
-                JiraRestClient restClient;
                 if (useBearerAuth) {
                     BearerAuthenticationHandler handler = new BearerAuthenticationHandler(pass.getPlainText());
                     restClient = new AsynchronousJiraRestClientV3(uri, httpClientFactory.createClient(uri, handler));
@@ -781,6 +783,14 @@ public class JiraTestDataPublisher extends TestDataPublisher {
             } catch (Exception e) {
                 JiraUtils.logError("ERROR: Unknown error", e);
                 return FormValidation.error("ERROR Unknown: " + e.getMessage());
+            } finally {
+                if (restClient != null) {
+                    try {
+                        restClient.close();
+                    } catch (Exception e) {
+                        JiraUtils.logWarning("Failed to close Jira REST client", e);
+                    }
+                }
             }
 
             return FormValidation.ok(serverName);

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestResultReporterPlugin.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestResultReporterPlugin.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.JiraTestResultReporter;
 
-import hudson.Plugin;
 import hudson.model.Api;
 import org.jenkinsci.plugins.JiraTestResultReporter.api.TestToIssueMappingApi;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -9,7 +8,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  * Created by tuicu on 05/08/16.
  */
 @ExportedBean
-public class JiraTestResultReporterPlugin extends Plugin {
+public class JiraTestResultReporterPlugin {
     public Api getTestToIssueMapping() {
         return new TestToIssueMappingApi();
     }

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/SelectableArrayFields.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/SelectableArrayFields.java
@@ -158,9 +158,10 @@ public class SelectableArrayFields extends AbstractFields {
                             CustomFieldOption option = (CustomFieldOption) o;
                             listBox.add(option.getValue(), option.getId().toString());
                         } else if (o instanceof IdentifiableEntity && o instanceof NamedEntity) {
+                            IdentifiableEntity<?> identifiableEntity = (IdentifiableEntity<?>) o;
                             listBox.add(
                                     ((NamedEntity) o).getName(),
-                                    ((IdentifiableEntity<Long>) o).getId().toString());
+                                    identifiableEntity.getId().toString());
                             // work-around for Components and Fix Versions
                             // even though they have ids, for some reason they don't implement IdentifiableEntity
                             // so I'm invoking the getter for the id using reflection

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/SelectableFields.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/SelectableFields.java
@@ -145,9 +145,10 @@ public class SelectableFields extends AbstractFields {
                             CustomFieldOption option = (CustomFieldOption) o;
                             listBox.add(option.getValue(), option.getId().toString());
                         } else if (o instanceof IdentifiableEntity && o instanceof NamedEntity) {
+                            IdentifiableEntity<?> identifiableEntity = (IdentifiableEntity<?>) o;
                             listBox.add(
                                     ((NamedEntity) o).getName(),
-                                    ((IdentifiableEntity<Long>) o).getId().toString());
+                                    identifiableEntity.getId().toString());
                         }
                     }
                 }


### PR DESCRIPTION
 - fix issue with optional jiraBrowsableUri causing exception if left blank

`caught exception evaluating: it.issueUrl in /view/.../. Reason: java.lang.reflect.InvocationTargetException java.lang.NullPointerException: Cannot invoke "String.length()" because "serverURL" is null       at PluginClassLoader for JiraTestResultReporter//org.jenkinsci.plugins.JiraTestResultReporter.JiraUtils.getIssueURL(JiraUtils.java:65)       at PluginClassLoader for JiraTestResultReporter//org.jenkinsci.plugins.JiraTestResultReporter.JiraTestAction.getIssueUrl(JiraTestAction.java:166)       at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) Caused: java.lang.reflect.InvocationTargetException       at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:115)       at java.base/java.lang.reflect.Method.invoke(Method.java:580) ...`
- fixed mem leak
- fixed from #176 [WARNING] //JiraTestResultReporter-plugin/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/SelectableArrayFields.java:[162,61] unchecked cast
required: com.atlassian.jira.rest.client.api.IdentifiableEntity<java.lang.Long>
found: java.lang.Object
- fixed from #176 [WARNING] //JiraTestResultReporter-plugin/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestResultReporterPlugin.java:[12,8] Plugin() in hudson.Plugin has been deprecated
- fixed from #176 [WARNING] //JiraTestResultReporter-plugin/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/SelectableFields.java:[149,61] unchecked cast
required: com.atlassian.jira.rest.client.api.IdentifiableEntity<java.lang.Long>
found: java.lang.Object

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
