### PR TITLE
fix further compiler warnings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestData.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestData.java
@@ -51,6 +51,7 @@ public class JiraTestData extends TestResultAction.Data {
      * @return a test action
      */
     @Override
+    @SuppressWarnings("deprecation")
     public List<? extends TestAction> getTestAction(TestObject testObject) {
         if (testObject instanceof CaseResult) {
             CaseResult test = (CaseResult) testObject;

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JobConfigMapping.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JobConfigMapping.java
@@ -168,6 +168,7 @@ public class JobConfigMapping {
      * Builder for a JobConfigEntry
      */
     public static class JobConfigEntryBuilder extends JobConfigEntry {
+        private static final long serialVersionUID = 877647587L;
         /**
          * Constructor
          */

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/TestToIssueMapping.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/TestToIssueMapping.java
@@ -29,6 +29,7 @@ import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
 import java.io.OutputStreamWriter;
 import java.util.HashMap;
+import java.util.Map;
 import jenkins.model.Jenkins;
 
 /**
@@ -100,7 +101,17 @@ public class TestToIssueMapping {
         try {
             FileInputStream fileIn = new FileInputStream(getPathToFileMap(job));
             ObjectInputStream in = new ObjectInputStream(fileIn);
-            HashMap<String, String> testToIssue = (HashMap<String, String>) in.readObject();
+            Object serializedMap = in.readObject();
+            HashMap<String, String> testToIssue = new HashMap<String, String>();
+            if (serializedMap instanceof HashMap<?, ?>) {
+                HashMap<?, ?> rawMap = (HashMap<?, ?>) serializedMap;
+                for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+                    if (entry.getKey() != null && entry.getValue() != null) {
+                        testToIssue.put(
+                                entry.getKey().toString(), entry.getValue().toString());
+                    }
+                }
+            }
             JiraUtils.log(
                     "Found and successfully loaded issue map from a previous version for job: " + job.getFullName());
             saveMap(job, testToIssue);

--- a/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/UserFields.java
+++ b/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/config/UserFields.java
@@ -23,6 +23,7 @@ import org.kohsuke.stapler.QueryParameter;
  * Class for fields that accept user values
  */
 public class UserFields extends AbstractFields {
+    private static final long serialVersionUID = 670162057L;
     private String fieldKey;
     private String value;
     private transient User user;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fix further issues from https://github.com/jenkinsci/JiraTestResultReporter-plugin/issues/176

-  [WARNING] //JiraTestResultReporter-plugin/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/JiraTestData.java:[54,53] hudson.tasks.junit.TestObject in hudson.tasks.junit has been deprecated
- [WARNING] //JiraTestResultReporter-plugin/src/main/java/org/jenkinsci/plugins/JiraTestResultReporter/TestToIssueMapping.java:[103,90] unchecked cast
required: java.util.HashMap<java.lang.String,java.lang.String>
found: java.lang.Object
- add explicit serialVersionUID (https://www.baeldung.com/java-serial-version-uid) instead of implicit ones

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
